### PR TITLE
Add support for text2img models for inference

### DIFF
--- a/src/together/commands/inference.py
+++ b/src/together/commands/inference.py
@@ -105,6 +105,18 @@ def add_parser(subparsers: argparse._SubParsersAction[argparse.ArgumentParser]) 
         type=str,
         help="File name for text2img output images '-X.png' will be appended to this name, where X is a number.",
     )
+    inf_parser.add_argument(
+        "--height",
+        default=512,
+        type=int,
+        help="Height for images in text2img results",
+    )
+    inf_parser.add_argument(
+        "--width",
+        default=512,
+        type=int,
+        help="Width for images in text2img results",
+    )
 
     inf_parser.set_defaults(func=_run_complete)
 
@@ -125,6 +137,8 @@ def _run_complete(args: argparse.Namespace) -> None:
         seed=args.seed,
         results=args.results,
         output=args.output,
+        height=args.height,
+        width=args.width,
     )
 
     response = inference.inference(

--- a/src/together/inference.py
+++ b/src/together/inference.py
@@ -34,6 +34,8 @@ class Inference:
         seed: Optional[int] = 42,
         results: Optional[int] = 1,
         output: Optional[str] = "text2img",
+        height: Optional[int] = 512,
+        width: Optional[int] = 512,
     ) -> None:
         together_api_key = os.environ.get("TOGETHER_API_KEY", None)
         if together_api_key is None:
@@ -65,6 +67,8 @@ class Inference:
         self.seed = seed
         self.results = results
         self.output_file_name = output
+        self.height = height
+        self.width = width
 
     def inference(
         self,
@@ -92,6 +96,8 @@ class Inference:
                 "mode": self.task,
                 "steps": self.steps,
                 "seed": self.seed,
+                "height": self.height,
+                "width": self.width,
             }
         else:
             raise ValueError("Invalid task supplied")


### PR DESCRIPTION
Add inference for text2img models like SD and Universal SD. 
- Outputs images to .png files.
- Users can specify:
  - num results
  - seed
  - num steps
  - output-filename
  - height
  - width

Example command:
```
together complete --model togethercomputer/UniversalSD --prompt "Space robots" --output filename -r 3 --task text2img
```

Also, merged raw-inference function with the regular inference function to avoid repeated code. Resolved return type conflicts with `Union`.