### PR TITLE
Fix typo in error message of error code 429 in Complete.py

### DIFF
--- a/src/together/complete.py
+++ b/src/together/complete.py
@@ -69,7 +69,7 @@ class Complete:
                 You can start an instance with one of the following methods:
                   1. navigating to the Together Playground at api.together.ai
                   2. starting one in python using together.Models.start(model_name)
-                  3. `$ together models start <MODLE_NAME>` at the command line.
+                  3. `$ together models start <MODEL_NAME>` at the command line.
                 See `together.Models.list()` in python or `$ together models list` in command line
                 to get an updated list of valid model names.
                 """
@@ -151,7 +151,7 @@ class Complete:
                 You can start an instance with one of the following methods:
                   1. navigating to the Together Playground at api.together.ai
                   2. starting one in python using together.Models.start(model_name)
-                  3. `$ together models start <MODLE_NAME>` at the command line.
+                  3. `$ together models start <MODEL_NAME>` at the command line.
                 See `together.Models.list()` in python or `$ together models list` in command line
                 to get an updated list of valid model names.
                 """


### PR DESCRIPTION
This PR fixes a typo in the error output returned when no running instances are found and a completion request is made.