### PR TITLE
Change llama-2-70b finetune batch size to only be 96

### DIFF
--- a/src/together/finetune.py
+++ b/src/together/finetune.py
@@ -92,10 +92,10 @@ class Finetune:
         if (
             model
             in ["togethercomputer/llama-2-70b", "togethercomputer/llama-2-70b-chat"]
-            and batch_size != 144
+            and batch_size != 96
         ):
             raise ValueError(
-                f"Batch size must be 144 for {model} model. Please set batch size to 144"
+                f"Batch size must be 96 for {model} model. Please set batch size to 96"
             )
 
         # TODO: REMOVE THIS CHECK WHEN WE HAVE CHECKPOINTING WORKING FOR 70B models


### PR DESCRIPTION
llama-2-70b finetune batch size reduced to 96. For now this will be the only supported batch size. To be updated soon to allow a set of supported batch sizes (will be multiples of NUM_GPUS_PER_NODE * NUM_NODES, with a max batch size of 96)