### PR TITLE
wandb-url

### DIFF
--- a/src/together/finetune.py
+++ b/src/together/finetune.py
@@ -178,7 +178,7 @@ class Finetune:
         )
         if not response:
             return {}
-        
+
         response_dict = response_to_dict(response)
 
         response_dict[
@@ -186,7 +186,7 @@ class Finetune:
         ] = f"https://wandb.ai/{wandb_user_name}/together/groups/{response_dict['id']}/workspace?workspace=user-{wandb_user_name}"
 
         return response_dict
-        
+
     @classmethod
     def list(self) -> Dict[Any, Any]:
         # send request


### PR DESCRIPTION
https://github.com/togethercomputer/planning/issues/2698 this PR gives the user who is using Finetune.create() the URL to the wandb loss and lr curves: 

<img width="1213" alt="Screenshot 2023-10-06 at 9 36 19 AM" src="https://github.com/togethercomputer/together/assets/4342553/f5b39721-88b5-4c29-b70f-9dfd9f6b75cb">


<img width="1473" alt="Screenshot 2023-10-06 at 9 28 11 AM" src="https://github.com/togethercomputer/together/assets/4342553/6728eec6-8e45-4100-88fc-a349e8e082d6">


but they have to provide their wandb_user_name because i dont know that we can infer that from the api_key. 
```
        response_dict = response_to_dict(response)

        response_dict[
            "learning_progress_url"
        ] = f"https://wandb.ai/{wandb_user_name}/together/groups/{response_dict['id']}/workspace?workspace=user-{wandb_user_name}"

        return response_dict
```