### PR TITLE
Add max batch size check

### DIFF
--- a/src/together/finetune.py
+++ b/src/together/finetune.py
@@ -84,7 +84,6 @@ class Finetune:
             raise ValueError(
                 f"The max batch size for model {model} is {max_batch_size}. Received batch size {batch_size}."
             )
-        
 
         # TODO: REMOVE THIS CHECK WHEN WE HAVE CHECKPOINTING WORKING FOR 70B models
         if n_checkpoints > 1 and model in [


### PR DESCRIPTION
This PR raises a ValueError should the user specify a max size above what we support for the model

Things to change in the future:

1. The default batch size is 32, which is above max batch size for code llamas. They need a different default batch size.
2. We need to instead store min, max, and default batch size for each model in mongo, which can then be upaded separately and used in the CLI and finetune processor