### PR TITLE
Replace ValueError for max batchsize with ajusted_inputs=True

### DIFF
--- a/src/together/finetune.py
+++ b/src/together/finetune.py
@@ -81,9 +81,8 @@ class Finetune:
             max_batch_size = 8
 
         if batch_size > max_batch_size:
-            raise ValueError(
-                f"The max batch size for model {model} is {max_batch_size}. Received batch size {batch_size}."
-            )
+            batch_size = max_batch_size
+            adjusted_inputs = True
 
         # TODO: REMOVE THIS CHECK WHEN WE HAVE CHECKPOINTING WORKING FOR 70B models
         if n_checkpoints > 1 and model in [


### PR DESCRIPTION
Changes the value and informs the user instead of erroring.