### PR TITLE
Add wandb api key length check

### DIFF
--- a/src/together/finetune.py
+++ b/src/together/finetune.py
@@ -44,6 +44,20 @@ class Finetune:
     ) -> Dict[Any, Any]:
         adjusted_inputs = False
 
+        if wandb_api_key:
+            # Validate API key length
+            # Account for On-prem API keys having prefixes
+            wandb_prefix, wandb_suffix = (
+                wandb_api_key.split("-", 1)
+                if "-" in wandb_api_key
+                else ("", wandb_api_key)
+            )
+            if len(wandb_suffix) != 40:
+                raise ValueError(
+                    f"Provided WandB API key must be 40 characters long, yours was {len(suffix)}. "
+                    + "Double check the provided key or the WANDB_API_KEY environment variable."
+                )
+
         if n_epochs is None or n_epochs < 1:
             n_epochs = 1
             adjusted_inputs = True


### PR DESCRIPTION
Issue # https://linear.app/together-ai/issue/ENG-450/fine-tune-70b-job-failed-due-to-wandb-response-401

## Describe your changes

Adds a check to make sure the WandB api key (if provided) is the correct length. This matches the [check in the WandB library](https://github.com/wandb/wandb/blob/v0.16.0/wandb/sdk/lib/apikey.py#L234C2-L234C2). 

Note that this does not mean the api key is valid. Determining if it is possible to determine this conclusively without starting a new run. It seems WandB does not explicitly support this. 