### PR TITLE
Fix price label for finetune

### DIFF
--- a/src/together/commands/finetune.py
+++ b/src/together/commands/finetune.py
@@ -294,7 +294,7 @@ def _run_list(args: argparse.Namespace) -> None:
                     "Status": i.get("status"),
                     "Created At": i.get("created_at"),
                     "Price": finetune_price_to_dollars(
-                        float(str(i.get("total_price")))
+                        float(str(i.get("price")))
                     ),  # convert to string for mypy typing
                 }
             )


### PR DESCRIPTION
This PR updates together cli to use price instead of total_price. This issue is caused by an inconsistency in together-finetune bson/json labels.
