### PR TITLE
Fix missing keys in report_dict for _check_jsonl

### DIFF
--- a/src/together/utils/files.py
+++ b/src/together/utils/files.py
@@ -149,11 +149,11 @@ def _check_jsonl(file: Path) -> Dict[str, Any]:
                 )
             report_dict["is_check_passed"] = False
 
-    if report_dict["text_field"] is not False:
+    if "text_field" not in report_dict:
         report_dict["text_field"] = True
-    if report_dict["line_type"] is not False:
+    if "line_type" not in report_dict:
         report_dict["line_type"] = True
-    if report_dict["key_value"] is not False:
+    if "key_value" not in report_dict:
         report_dict["key_value"] = True
     return report_dict
 


### PR DESCRIPTION
Due to the changes in https://github.com/togethercomputer/together-python/pull/73, there is now a separate report_dict that is created in `_check_jsonl`. The end of the function checks for multiple keys in that dictionary that are not created by default. This PR fixes the problem by checking for the presence of the key in the dictionary instead