### PR TITLE
Bump version to 1.1.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ build-backend = "poetry.masonry.api"
 
 [tool.poetry]
 name = "together"
-version = "1.1.0"
+version = "1.1.1"
 authors = [
     "Together AI <support@together.ai>"
 ]


### PR DESCRIPTION
This PR increments the version to enable publishing a hotfixed version after https://github.com/togethercomputer/together-python/pull/93