### PR TITLE
WandB API Param Name fix

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ build-backend = "poetry.masonry.api"
 
 [tool.poetry]
 name = "together"
-version = "1.1.1"
+version = "1.1.2"
 authors = [
     "Together AI <support@together.ai>"
 ]

--- a/src/together/resources/finetune.py
+++ b/src/together/resources/finetune.py
@@ -66,7 +66,7 @@ class FineTuning:
             batch_size=batch_size,
             learning_rate=learning_rate,
             suffix=suffix,
-            wandb_api_key=wandb_api_key,
+            wandb_key=wandb_api_key,
         ).model_dump()
 
         response, _, _ = requestor.request(
@@ -280,7 +280,7 @@ class AsyncFineTuning:
             batch_size=batch_size,
             learning_rate=learning_rate,
             suffix=suffix,
-            wandb_api_key=wandb_api_key,
+            wandb_key=wandb_api_key,
         ).model_dump()
 
         response, _, _ = await requestor.arequest(

--- a/src/together/types/finetune.py
+++ b/src/together/types/finetune.py
@@ -118,7 +118,7 @@ class FinetuneRequest(BaseModel):
     # up to 40 character suffix for output model name
     suffix: str | None = None
     # weights & biases api key
-    wandb_api_key: str | None = None
+    wandb_key: str | None = None
 
 
 class FinetuneResponse(BaseModel):


### PR DESCRIPTION
This resolves an issue where the WandB API Key was ignored since it was using the wrong field name in the request.