### PR TITLE
Add required parameter max_tokens to completions example

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ client = Together(api_key=os.environ.get("TOGETHER_API_KEY"))
 response = client.completions.create(
     model="codellama/CodeLlama-34b-Python-hf",
     prompt="Write a Next.js component with TailwindCSS for a header component.",
+    max_tokens=200,
 )
 print(response.choices[0].text)
 ```


### PR DESCRIPTION
I have read the contributing guidelines. Formatting and linting and unit testing checks have been done.

Issue #: None

## Describe your changes

The Completions endpoint requires the `max_tokens` parameter. This has been added to the example Completions request in `README.md`
