### PR TITLE
Default FineTune Download File to zstd

### DIFF
--- a/src/together/filemanager.py
+++ b/src/together/filemanager.py
@@ -103,13 +103,8 @@ def _prepare_output(
     if "x-tar" in content_type.lower():
         remote_name += ".tar.gz"
 
-    elif "zstd" in content_type.lower() or step != -1:
-        remote_name += ".tar.zst"
-
     else:
-        raise FileTypeError(
-            f"Unknown file type {content_type} found. Aborting download."
-        )
+        remote_name += ".tar.zst"
 
     return Path(remote_name)
 


### PR DESCRIPTION
*Have you read the [Contributing Guidelines](https://github.com/togethercomputer/together/blob/main/CONTRIBUTING.md)?* 
Yes

## Describe your changes

Intermediate fine-tune checkpoints are missing content-type. We can update future uploads to have this, but backfilling will be difficult. Thus, this change sets the default to zstd for download purposes.
