### PR TITLE
Check uploaded files by default

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ build-backend = "poetry.masonry.api"
 
 [tool.poetry]
 name = "together"
-version = "1.1.5"
+version = "1.2.0"
 authors = [
     "Together AI <support@together.ai>"
 ]

--- a/src/together/cli/api/files.py
+++ b/src/together/cli/api/files.py
@@ -32,12 +32,17 @@ def files(ctx: click.Context) -> None:
     default=FilePurpose.FineTune.value,
     help="Purpose of file upload. Acceptable values in enum `together.types.FilePurpose`. Defaults to `fine-tunes`.",
 )
-def upload(ctx: click.Context, file: pathlib.Path, purpose: str) -> None:
+@click.option(
+    "--check/--no-check",
+    default=True,
+    help="Whether to check the file before uploading.",
+)
+def upload(ctx: click.Context, file: pathlib.Path, purpose: str, check: bool) -> None:
     """Upload file"""
 
     client: Together = ctx.obj
 
-    response = client.files.upload(file=file, purpose=purpose)
+    response = client.files.upload(file=file, purpose=purpose, check=check)
 
     click.echo(json.dumps(response.model_dump(), indent=4))
 

--- a/src/together/error.py
+++ b/src/together/error.py
@@ -23,9 +23,12 @@ class TogetherException(Exception):
             if isinstance(message, TogetherErrorResponse)
             else message
         )
-        self._message = f"Error code: {http_status} - {_message}"
+        if http_status is not None:
+            self._message = f"Error code: {http_status} - {_message}"
+        else:
+            self._message = str(_message)
 
-        super(TogetherException, self).__init__(self._message)
+        super().__init__(self._message)
 
         self.http_status = http_status
         self.headers = headers or {}

--- a/src/together/legacy/files.py
+++ b/src/together/legacy/files.py
@@ -53,9 +53,11 @@ class Files:
 
         client = together.Together(api_key=api_key)
 
-        response = client.files.upload(file=file).model_dump()
+        # disabling the check, because it was run previously
+        response = client.files.upload(file=file, check=False).model_dump()
 
-        response["report_dict"] = report_dict
+        if check:
+            response["report_dict"] = report_dict
 
         return response
 


### PR DESCRIPTION
Issue # ENG-5104

## Describe your changes

This PR reverts the old behavior of checking files by default, because the current logic leads to many incorrect files being uploaded, adding friction to user experience (the error messages seen by users do not reveal the source of errors). If users want to skip the check (for example, they are sure the file is correct and checking it takes a long time), they can disable it with `--no-check`