### PR TITLE
Add LoRA support for FT API

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ build-backend = "poetry.masonry.api"
 
 [tool.poetry]
 name = "together"
-version = "1.2.2"
+version = "1.2.3"
 authors = [
     "Together AI <support@together.ai>"
 ]

--- a/src/together/cli/api/finetune.py
+++ b/src/together/cli/api/finetune.py
@@ -28,7 +28,7 @@ def fine_tuning(ctx: click.Context) -> None:
 )
 @click.option("--batch-size", type=int, default=32, help="Train batch size")
 @click.option("--learning-rate", type=float, default=1e-5, help="Learning rate")
-@click.option("--lora/--no-lora", type=bool, default=False, help="LoRA mode")
+@click.option("--lora/--no-lora", type=bool, default=False, help="Whether to use LoRA adapters for fine-tuning")
 @click.option("--lora-r", type=int, default=8, help="LoRA adapters' rank")
 @click.option("--lora-dropout", type=float, default=0, help="LoRA adapters' dropout")
 @click.option("--lora-alpha", type=float, default=8, help="LoRA adapters' alpha")
@@ -36,7 +36,7 @@ def fine_tuning(ctx: click.Context) -> None:
     "--lora-trainable-modules",
     type=str,
     default="all-linear",
-    help="LoRA adapters' trainable modules. For example, 'all-linear', 'q_proj,v_proj'",
+    help="Trainable modules for LoRA adapters. For example, 'all-linear', 'q_proj,v_proj'",
 )
 @click.option(
     "--suffix", type=str, default=None, help="Suffix for the fine-tuned model name"
@@ -70,8 +70,8 @@ def create(
             param_source = click.get_current_context().get_parameter_source(param)
             if param_source != ParameterSource.DEFAULT:
                 raise click.BadParameter(
-                    f"You set LoRA parameter {param} for a Full finetune job. "
-                    f"Please, change the job type with --lora or remove {param} from the arguments"
+                    f"You set LoRA parameter `{param}` for a full fine-tuning job. "
+                    f"Please change the job type with --lora or remove `{param}` from the arguments"
                 )
 
     response = client.fine_tuning.create(

--- a/src/together/cli/api/finetune.py
+++ b/src/together/cli/api/finetune.py
@@ -2,7 +2,7 @@ import json
 from textwrap import wrap
 
 import click
-from click.core import ParameterSource
+from click.core import ParameterSource  # type: ignore[attr-defined]
 from tabulate import tabulate
 
 from together import Together
@@ -67,14 +67,14 @@ def create(
     client: Together = ctx.obj
 
     if lora:
-        learning_rate_source = click.get_current_context().get_parameter_source(
+        learning_rate_source = click.get_current_context().get_parameter_source(  # type: ignore[attr-defined]
             "learning_rate"
         )
         if learning_rate_source == ParameterSource.DEFAULT:
             learning_rate = 1e-3
     else:
         for param in ["lora_r", "lora_dropout", "lora_alpha", "lora_trainable_modules"]:
-            param_source = click.get_current_context().get_parameter_source(param)
+            param_source = click.get_current_context().get_parameter_source(param)  # type: ignore[attr-defined]
             if param_source != ParameterSource.DEFAULT:
                 raise click.BadParameter(
                     f"You set LoRA parameter `{param}` for a full fine-tuning job. "

--- a/src/together/cli/api/finetune.py
+++ b/src/together/cli/api/finetune.py
@@ -28,7 +28,12 @@ def fine_tuning(ctx: click.Context) -> None:
 )
 @click.option("--batch-size", type=int, default=32, help="Train batch size")
 @click.option("--learning-rate", type=float, default=1e-5, help="Learning rate")
-@click.option("--lora/--no-lora", type=bool, default=False, help="Whether to use LoRA adapters for fine-tuning")
+@click.option(
+    "--lora/--no-lora",
+    type=bool,
+    default=False,
+    help="Whether to use LoRA adapters for fine-tuning",
+)
 @click.option("--lora-r", type=int, default=8, help="LoRA adapters' rank")
 @click.option("--lora-dropout", type=float, default=0, help="LoRA adapters' dropout")
 @click.option("--lora-alpha", type=float, default=8, help="LoRA adapters' alpha")
@@ -62,7 +67,9 @@ def create(
     client: Together = ctx.obj
 
     if lora:
-        learning_rate_source = click.get_current_context().get_parameter_source('learning_rate')
+        learning_rate_source = click.get_current_context().get_parameter_source(
+            "learning_rate"
+        )
         if learning_rate_source == ParameterSource.DEFAULT:
             learning_rate = 1e-3
     else:

--- a/src/together/resources/finetune.py
+++ b/src/together/resources/finetune.py
@@ -53,7 +53,7 @@ class FineTuning:
             learning_rate (float, optional): Learning rate multiplier to use for training
                 Defaults to 0.00001.
             lora (bool, optional): Whether to use LoRA adapters. Defaults to True.
-            lora_r (int, optional): Whether to use LoRA R. Defaults to 8.
+            lora_r (int, optional): Rank of LoRA adapters. Defaults to 8.
             lora_dropout (float, optional): Dropout rate for LoRA adapters. Defaults to 0.
             lora_alpha (float, optional): Alpha for LoRA adapters. Defaults to 8.
             lora_trainable_modules (str, optional): Trainable modules for LoRA adapters. Defaults to "all-linear".

--- a/src/together/resources/finetune.py
+++ b/src/together/resources/finetune.py
@@ -6,15 +6,16 @@ from together.abstract import api_requestor
 from together.filemanager import DownloadManager
 from together.together_response import TogetherResponse
 from together.types import (
-    FullTrainingType,
-    LoRATrainingType,
     FinetuneDownloadResult,
     FinetuneList,
     FinetuneListEvents,
     FinetuneRequest,
     FinetuneResponse,
+    FullTrainingType,
+    LoRATrainingType,
     TogetherClient,
     TogetherRequest,
+    TrainingType,
 )
 from together.utils import normalize_key
 
@@ -69,9 +70,8 @@ class FineTuning:
         requestor = api_requestor.APIRequestor(
             client=self._client,
         )
-        
-        training_type = FullTrainingType()
 
+        training_type: TrainingType = FullTrainingType()
         if lora:
             training_type = LoRATrainingType(
                 lora_r=lora_r,

--- a/src/together/resources/finetune.py
+++ b/src/together/resources/finetune.py
@@ -6,6 +6,8 @@ from together.abstract import api_requestor
 from together.filemanager import DownloadManager
 from together.together_response import TogetherResponse
 from together.types import (
+    FullTrainingType,
+    LoRATrainingType,
     FinetuneDownloadResult,
     FinetuneList,
     FinetuneListEvents,
@@ -30,6 +32,11 @@ class FineTuning:
         n_checkpoints: int | None = 1,
         batch_size: int | None = 32,
         learning_rate: float | None = 0.00001,
+        lora: bool = True,
+        lora_r: int | None = 8,
+        lora_dropout: float | None = 0,
+        lora_alpha: float | None = 8,
+        lora_trainable_modules: str | None = "all-linear",
         suffix: str | None = None,
         wandb_api_key: str | None = None,
     ) -> FinetuneResponse:
@@ -45,6 +52,11 @@ class FineTuning:
             batch_size (int, optional): Batch size for fine-tuning. Defaults to 32.
             learning_rate (float, optional): Learning rate multiplier to use for training
                 Defaults to 0.00001.
+            lora (bool, optional): Whether to use LoRA adapters. Defaults to True.
+            lora_r (int, optional): Whether to use LoRA R. Defaults to 8.
+            lora_dropout (float, optional): Dropout rate for LoRA adapters. Defaults to 0.
+            lora_alpha (float, optional): Alpha for LoRA adapters. Defaults to 8.
+            lora_trainable_modules (str, optional): Trainable modules for LoRA adapters. Defaults to "all-linear".
             suffix (str, optional): Up to 40 character suffix that will be added to your fine-tuned model name.
                 Defaults to None.
             wandb_api_key (str, optional): API key for Weights & Biases integration.
@@ -57,6 +69,16 @@ class FineTuning:
         requestor = api_requestor.APIRequestor(
             client=self._client,
         )
+        
+        training_type = FullTrainingType()
+
+        if lora:
+            training_type = LoRATrainingType(
+                lora_r=lora_r,
+                lora_alpha=lora_alpha,
+                lora_dropout=lora_dropout,
+                lora_trainable_modules=lora_trainable_modules,
+            )
 
         parameter_payload = FinetuneRequest(
             model=model,
@@ -65,6 +87,7 @@ class FineTuning:
             n_checkpoints=n_checkpoints,
             batch_size=batch_size,
             learning_rate=learning_rate,
+            training_type=training_type,
             suffix=suffix,
             wandb_key=wandb_api_key,
         ).model_dump()

--- a/src/together/types/__init__.py
+++ b/src/together/types/__init__.py
@@ -28,6 +28,7 @@ from together.types.finetune import (
     FinetuneResponse,
     FullTrainingType,
     LoRATrainingType,
+    TrainingType,
 )
 from together.types.images import (
     ImageRequest,
@@ -62,6 +63,7 @@ __all__ = [
     "ImageRequest",
     "ImageResponse",
     "ModelObject",
+    "TrainingType",
     "FullTrainingType",
     "LoRATrainingType",
 ]

--- a/src/together/types/__init__.py
+++ b/src/together/types/__init__.py
@@ -26,6 +26,8 @@ from together.types.finetune import (
     FinetuneListEvents,
     FinetuneRequest,
     FinetuneResponse,
+    FullTrainingType,
+    LoRATrainingType,
 )
 from together.types.images import (
     ImageRequest,
@@ -60,4 +62,6 @@ __all__ = [
     "ImageRequest",
     "ImageResponse",
     "ModelObject",
+    "FullTrainingType",
+    "LoRATrainingType",
 ]

--- a/src/together/types/finetune.py
+++ b/src/together/types/finetune.py
@@ -98,26 +98,29 @@ class FinetuneEvent(BaseModel):
     wandb_url: str | None = None
     # event hash
     hash: str | None = None
-    
-    
+
+
 class TrainingType(BaseModel):
     """
     Abstract training type
     """
-    type: Literal["Full", "Lora"]
-    
-    
+
+    type: str
+
+
 class FullTrainingType(TrainingType):
     """
     Training type for full fine-tuning
     """
+
     type: str = "Full"
-    
-    
+
+
 class LoRATrainingType(TrainingType):
     """
     Training type for LoRA adapters training
     """
+
     lora_r: int
     lora_alpha: int
     lora_dropout: float

--- a/src/together/types/finetune.py
+++ b/src/together/types/finetune.py
@@ -116,7 +116,7 @@ class FullTrainingType(TrainingType):
     
 class LoRATrainingType(TrainingType):
     """
-    Training type for LoRa adapters training
+    Training type for LoRA adapters training
     """
     lora_r: int
     lora_alpha: int

--- a/src/together/types/finetune.py
+++ b/src/together/types/finetune.py
@@ -98,6 +98,31 @@ class FinetuneEvent(BaseModel):
     wandb_url: str | None = None
     # event hash
     hash: str | None = None
+    
+    
+class TrainingType(BaseModel):
+    """
+    Abstract training type
+    """
+    type: Literal["Full", "Lora"]
+    
+    
+class FullTrainingType(TrainingType):
+    """
+    Training type for full fine-tuning
+    """
+    type: str = "Full"
+    
+    
+class LoRATrainingType(TrainingType):
+    """
+    Training type for LoRa adapters training
+    """
+    lora_r: int
+    lora_alpha: int
+    lora_dropout: float
+    lora_trainable_modules: str
+    type: str = "Lora"
 
 
 class FinetuneRequest(BaseModel):
@@ -121,6 +146,7 @@ class FinetuneRequest(BaseModel):
     suffix: str | None = None
     # weights & biases api key
     wandb_key: str | None = None
+    training_type: FullTrainingType | LoRATrainingType | None = None
 
 
 class FinetuneResponse(BaseModel):
@@ -138,6 +164,8 @@ class FinetuneResponse(BaseModel):
     model: str | None = None
     # output model name
     output_name: str | None = Field(None, alias="model_output_name")
+    # adapter output name
+    adapter_output_name: str | None = None
     # number of epochs
     n_epochs: int | None = None
     # number of checkpoints to save
@@ -148,11 +176,8 @@ class FinetuneResponse(BaseModel):
     learning_rate: float | None = None
     # number of steps between evals
     eval_steps: int | None = None
-    # is LoRA finetune boolean
-    lora: bool | None = None
-    lora_r: int | None = None
-    lora_alpha: int | None = None
-    lora_dropout: int | None = None
+    # training type
+    training_type: FullTrainingType | LoRATrainingType | None = None
     # created/updated datetime stamps
     created_at: str | None = None
     updated_at: str | None = None


### PR DESCRIPTION
Issue ENG-4853

Add LoRA training support for finetuning jobs.

Some cli examples:

```bash
together fine-tuning create --training-file "${FILE_ID}" --model "meta-llama/Meta-Llama-3-8B" --wandb-api-key "${WANDB_API_KEY}" --lora --lora-r 8
```

Description of the new parameters:

- `--lora`(bool) -- general flag for enabling LoRA training
- `--lora-r`(int) -- rank for LoRA adapter weights
- `--lora-dropout`(float) -- dropout value for LoRA adapter training
- `--lora-alpha`(int) -- alpha value for LoRA adapter training
- `--lora-trainable-modules`(str) -- LoRA adapters' trainable modules, separated by a comma. To use trainable modules, use `all-linear`
