### PR TITLE
Change default batch size to be accepted for all models

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ build-backend = "poetry.masonry.api"
 
 [tool.poetry]
 name = "together"
-version = "1.2.5"
+version = "1.2.6"
 authors = [
     "Together AI <support@together.ai>"
 ]

--- a/src/together/cli/api/finetune.py
+++ b/src/together/cli/api/finetune.py
@@ -26,7 +26,7 @@ def fine_tuning(ctx: click.Context) -> None:
 @click.option(
     "--n-checkpoints", type=int, default=1, help="Number of checkpoints to save"
 )
-@click.option("--batch-size", type=int, default=32, help="Train batch size")
+@click.option("--batch-size", type=int, default=16, help="Train batch size")
 @click.option("--learning-rate", type=float, default=1e-5, help="Learning rate")
 @click.option(
     "--lora/--no-lora",

--- a/src/together/resources/finetune.py
+++ b/src/together/resources/finetune.py
@@ -31,7 +31,7 @@ class FineTuning:
         model: str,
         n_epochs: int = 1,
         n_checkpoints: int | None = 1,
-        batch_size: int | None = 32,
+        batch_size: int | None = 16,
         learning_rate: float | None = 0.00001,
         lora: bool = True,
         lora_r: int | None = 8,


### PR DESCRIPTION
## Describe your changes

Change the default value for batch size from 32 to 16. The last one is acceptable by all models.