### PR TITLE
Add rerank to ModelType enum

### DIFF
--- a/src/together/types/models.py
+++ b/src/together/types/models.py
@@ -14,6 +14,7 @@ class ModelType(str, Enum):
     IMAGE = "image"
     EMBEDDING = "embedding"
     MODERATION = "moderation"
+    RERANK = "rerank"
 
 
 class PricingObject(BaseModel):


### PR DESCRIPTION
Fixes #173

Adds the `rerank` value to the `ModelType` enum. This allows the Python library to deserialize model objects of the `rerank` type.