### PR TITLE
ENG-10038: Use Union instead of Conditional Or For DownloadCheckpointTypeChoice Typing

### DIFF
--- a/src/together/cli/api/finetune.py
+++ b/src/together/cli/api/finetune.py
@@ -9,13 +9,18 @@ from together import Together
 from together.utils import finetune_price_to_dollars, log_warn, parse_timestamp
 from together.types.finetune import DownloadCheckpointType
 
+from typing import Union
+
 
 class DownloadCheckpointTypeChoice(click.Choice):
     def __init__(self) -> None:
         super().__init__([ct.value for ct in DownloadCheckpointType])
 
     def convert(
-        self, value: str, param: click.Parameter | None, ctx: click.Context | None
+        self,
+        value: str,
+        param: Union[click.Parameter, None],
+        ctx: Union[click.Context, None],
     ) -> DownloadCheckpointType:
         value = super().convert(value, param, ctx)
         return DownloadCheckpointType(value)


### PR DESCRIPTION
FIXES ENG-10038

With any call to the together cli using Python 3.9

```
Traceback (most recent call last):
  File "/Users/arshzahed/.pyenv/versions/3.9.17/bin/together", line 5, in <module>
    from together.cli.cli import main
  File "/Users/arshzahed/.pyenv/versions/3.9.17/lib/python3.9/site-packages/together/cli/cli.py", line 12, in <module>
    from together.cli.api.finetune import fine_tuning
  File "/Users/arshzahed/.pyenv/versions/3.9.17/lib/python3.9/site-packages/together/cli/api/finetune.py", line 13, in <module>
    class DownloadCheckpointTypeChoice(click.Choice):
  File "/Users/arshzahed/.pyenv/versions/3.9.17/lib/python3.9/site-packages/together/cli/api/finetune.py", line 18, in DownloadCheckpointTypeChoice
    self, value: str, param: click.Parameter | None, ctx: click.Context | None
TypeError: unsupported operand type(s) for |: 'type' and 'NoneType'
```

This is due to unsupported syntax in Python < 3.10. We require Python support >= 3.8. 

This PR uses the Union typing instead of the conditional or, resolving the syntax issue.
