### PR TITLE
ENG 9390: Files MIN_SAMPLES=1

### DIFF
--- a/src/together/constants.py
+++ b/src/together/constants.py
@@ -19,7 +19,7 @@ Please set it as an environment variable or set it as together.api_key
 Find your TOGETHER_API_KEY at https://api.together.xyz/settings/api-keys"""
 
 # Minimum number of samples required for fine-tuning file
-MIN_SAMPLES = 100
+MIN_SAMPLES = 1
 
 # the number of bytes in a gigabyte, used to convert bytes to GB for readable comparison
 NUM_BYTES_IN_GB = 2**30


### PR DESCRIPTION
To support smaller validation datasets, the minimum dataset sample size is being reduced to 1 (we still need to make sure the dataset is nonempty). This is a single integer constant change.

```
$ cat ../test.jsonl 
{"text": "hi"}
$ together files check ../test.jsonl
{
    "is_check_passed": true,
    "message": "Checks passed",
    "found": true,
    "file_size": 15,
    "utf8": true,
    "line_type": true,
    "text_field": true,
    "key_value": true,
    "min_samples": true,
    "num_samples": 1,
    "load_json": true,
    "filetype": "jsonl"
}
```