### PR TITLE
Add a confirmation message before submitting a fine-tuning job

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ build-backend = "poetry.masonry.api"
 
 [tool.poetry]
 name = "together"
-version = "1.3.0"
+version = "1.2.12"
 authors = [
     "Together AI <support@together.ai>"
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ build-backend = "poetry.masonry.api"
 
 [tool.poetry]
 name = "together"
-version = "1.2.12"
+version = "1.3.0"
 authors = [
     "Together AI <support@together.ai>"
 ]

--- a/src/together/cli/api/finetune.py
+++ b/src/together/cli/api/finetune.py
@@ -15,11 +15,11 @@ from together.utils import finetune_price_to_dollars, log_warn, parse_timestamp
 
 
 _CONFIRMATION_MESSAGE = (
-    "You are about to launch a fine-tuning job. "
+    "You are about to create a fine-tuning job. "
     "The cost of your job will be determined by the model size, the number of tokens "
     "in the training file, the number of tokens in the validation file, the number of epochs, and "
     "the number of evaluations. Visit https://www.together.ai/pricing to get a price estimate.\n"
-    "You can add `-y` or `--confirm` to skip this message.\n\n"
+    "You can pass `-y` or `--confirm` to your command to skip this message.\n\n"
     "Do you want to proceed?"
 )
 

--- a/src/together/cli/api/finetune.py
+++ b/src/together/cli/api/finetune.py
@@ -152,7 +152,9 @@ def create(
 
         report_string = f"Successfully submitted a fine-tuning job {response.id}"
         if response.created_at is not None:
-            created_time = datetime.strptime(response.created_at, "%Y-%m-%dT%H:%M:%S.%f%z")
+            created_time = datetime.strptime(
+                response.created_at, "%Y-%m-%dT%H:%M:%S.%f%z"
+            )
             # created_at reports UTC time, we use .astimezone() to convert to local time
             formatted_time = created_time.astimezone().strftime("%m/%d/%Y, %H:%M:%S")
             report_string += f" at {formatted_time}"


### PR DESCRIPTION
This PR adds a confirmation message before submitting a fine-tuning job via CLI to communicate the pricing model to the users. Users can skip this message when they submit a job with `-y` or `--confirm` in the set of arguments.

Example output:
```
poetry run together fine-tuning create --training-file $FILE_NAME --model meta-llama/Meta-Llama-3-70B-Instruct --n-epochs 3 --n-checkpoints 3 --no-lora --batch-size 16 --wandb-api-key $WANDB_KEY  --suffix llama3_70b_full
You are about to launch a fine-tuning job. The cost of your job will be determined by the model size, the number of tokens in the training file, the number of tokens in the validation file, the number of epochs, and the number of evaluations. Visit https://www.together.ai/pricing to get a price estimate.
You can add `-y` or `--confirm` to skip this message.

Do you want to proceed? [Y/n]:
```
If the user presses Enter, the job proceeds automatically.

If the user declines:
```
You are about to launch a fine-tuning job. The cost of your job will be determined by the model size, the number of tokens in the training file, the number of tokens in the validation file, the number of epochs, and the number of evaluations. Visit https://www.together.ai/pricing to get a price estimate.
You can add `-y` or `--confirm` to skip this message.

Do you want to proceed? [Y/n]: n
No confirmation received, stopping job launch
```

If the user passes `-y`, the job proceeds automatically:
```
poetry run together fine-tuning create --training-file $FILE_NAME --model meta-llama/Meta-Llama-3-70B-Instruct --n-epochs 3 --n-checkpoints 3 --no-lora --batch-size 16 --wandb-api-key $WANDB_KEY   --suffix llama3_70b_full -y
message='The default value of batch size has been changed from 32 to 16 since together version >= 1.2.6'
```

Fixes ENG-10379