### PR TITLE
Fix handling of integers in AutoIntParamType

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ build-backend = "poetry.masonry.api"
 
 [tool.poetry]
 name = "together"
-version = "1.3.2"
+version = "1.3.3"
 authors = [
     "Together AI <support@together.ai>"
 ]

--- a/src/together/cli/api/utils.py
+++ b/src/together/cli/api/utils.py
@@ -1,23 +1,30 @@
 from __future__ import annotations
 
-import click
-
+from gettext import gettext as _
 from typing import Literal
+
+import click
 
 
 class AutoIntParamType(click.ParamType):
-    name = "integer"
+    name = "integer_or_max"
+    _number_class = int
 
     def convert(
         self, value: str, param: click.Parameter | None, ctx: click.Context | None
     ) -> int | Literal["max"] | None:
-        if isinstance(value, int):
-            return value
-
         if value == "max":
             return "max"
-
-        self.fail("Invalid integer value: {value}")
+        try:
+            return int(value)
+        except ValueError:
+            self.fail(
+                _("{value!r} is not a valid {number_type}.").format(
+                    value=value, number_type=self.name
+                ),
+                param,
+                ctx,
+            )
 
 
 INT_WITH_MAX = AutoIntParamType()


### PR DESCRIPTION
The current implementation of `AutoIntParamType.convert` returns integers only when integers are passed as `value`. However, `value` is defined as a string, so this branch of the code never gets used. As a result, passing `--batch-size 16` (or any other integer) to the command for creating jobs fails with the following error:
```
Error: Invalid value for '--batch-size': Invalid integer value: {value}
```

This PR fixes that error, moving over the code to handle integer inputs correctly from Click