### PR TITLE
Add check for unneeded jsonl columns

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ build-backend = "poetry.masonry.api"
 
 [tool.poetry]
 name = "together"
-version = "1.3.6"
+version = "1.3.7"
 authors = [
     "Together AI <support@together.ai>"
 ]

--- a/src/together/utils/files.py
+++ b/src/together/utils/files.py
@@ -120,7 +120,8 @@ def _check_jsonl(file: Path) -> Dict[str, Any]:
                     raise InvalidFileFormatError(
                         message=(
                             f"Error parsing file. Invalid format on line {idx + 1} of the input file. "
-                            'Example of valid json: {"text": "my sample string"}. '
+                            "Datasets must follow text, conversational, or instruction format. For more"
+                            "information, see https://docs.together.ai/docs/fine-tuning-data-preparation"
                         ),
                         line_number=idx + 1,
                         error_source="line_type",

--- a/src/together/utils/files.py
+++ b/src/together/utils/files.py
@@ -150,7 +150,7 @@ def _check_jsonl(file: Path) -> Dict[str, Any]:
                                 not in JSONL_REQUIRED_COLUMNS_MAP[possible_format]
                             ):
                                 raise InvalidFileFormatError(
-                                    message=f"Found extra column {column} in the line {idx + 1}.",
+                                    message=f'Found extra column "{column}" in the line {idx + 1}.',
                                     line_number=idx + 1,
                                     error_source="format",
                                 )

--- a/src/together/utils/files.py
+++ b/src/together/utils/files.py
@@ -142,7 +142,7 @@ def _check_jsonl(file: Path) -> Dict[str, Any]:
                                 error_source="format",
                             )
 
-                        # Check that there are not extra columns
+                        # Check that there are no extra columns
                         for column in json_line:
                             if (
                                 column

--- a/src/together/utils/files.py
+++ b/src/together/utils/files.py
@@ -142,6 +142,18 @@ def _check_jsonl(file: Path) -> Dict[str, Any]:
                                 error_source="format",
                             )
 
+                        # Check that there are not extra columns
+                        for column in json_line:
+                            if (
+                                column
+                                not in JSONL_REQUIRED_COLUMNS_MAP[possible_format]
+                            ):
+                                raise InvalidFileFormatError(
+                                    message=f"Found extra column {column} in the line {idx + 1}.",
+                                    line_number=idx + 1,
+                                    error_source="format",
+                                )
+
                 if current_format is None:
                     raise InvalidFileFormatError(
                         message=(

--- a/tests/unit/test_files_checks.py
+++ b/tests/unit/test_files_checks.py
@@ -279,3 +279,14 @@ def test_check_jsonl_wrong_turn_type(tmp_path: Path):
         "Invalid format on line 1 of the input file. Expected a dictionary"
         in report["message"]
     )
+
+
+def test_check_jsonl_extra_column(tmp_path: Path):
+    file = tmp_path / "extra_column.jsonl"
+    content = [{"text": "Hello, world!", "extra_column": "extra"}]
+    with file.open("w") as f:
+        f.write("\n".join(json.dumps(item) for item in content))
+
+    report = check_file(file)
+    assert not report["is_check_passed"]
+    assert "Found extra column" in report["message"]


### PR DESCRIPTION
This PR adds a check that upload jsonl files do not have columns that aren't relevant. This will also ensure all columns have the same columns.

Part of ENG-14194/fix-ft-jsonl-datasets-error-with-the-extra-column