### PR TITLE
Change caught Exception to a BaseException so the HTTPSession is alwa…

### DIFF
--- a/src/together/abstract/api_requestor.py
+++ b/src/together/abstract/api_requestor.py
@@ -302,7 +302,7 @@ class APIRequestor:
                 request_timeout=request_timeout,
             )
             resp, got_stream = await self._interpret_async_response(result, stream)
-        except Exception:
+        except BaseException:
             # Close the request before exiting session context.
             if result is not None:
                 result.release()


### PR DESCRIPTION

*Have you read the [Contributing Guidelines](https://github.com/togethercomputer/together/blob/main/CONTRIBUTING.md)?* Yes

Issue # N/A

## Describe your changes

*Clearly and concisely describe what's in this pull request. Include screenshots, if necessary.*
This change fixes a bug where Exceptions which only inherited from BaseException not Exception were causing the HTTPSession to never get closed.