### PR TITLE
Support auto shutdown and model list

### DIFF
--- a/src/together/cli/api/models.py
+++ b/src/together/cli/api/models.py
@@ -1,4 +1,4 @@
-from textwrap import wrap
+import json as json_lib
 
 import click
 from tabulate import tabulate
@@ -20,8 +20,13 @@ def models(ctx: click.Context) -> None:
     type=click.Choice(["dedicated"]),
     help="Filter models by type (dedicated: models that support autoscaling)",
 )
+@click.option(
+    "--json",
+    is_flag=True,
+    help="Output in JSON format",
+)
 @click.pass_context
-def list(ctx: click.Context, type: str | None) -> None:
+def list(ctx: click.Context, type: str | None, json: bool) -> None:
     """List models"""
     client: Together = ctx.obj
 
@@ -44,4 +49,7 @@ def list(ctx: click.Context, type: str | None) -> None:
             }
         )
 
-    click.echo(tabulate(display_list, headers="keys", tablefmt="plain"))
+    if json:
+        click.echo(json_lib.dumps(display_list, indent=2))
+    else:
+        click.echo(tabulate(display_list, headers="keys", tablefmt="plain"))

--- a/src/together/cli/api/models.py
+++ b/src/together/cli/api/models.py
@@ -15,12 +15,17 @@ def models(ctx: click.Context) -> None:
 
 
 @models.command()
+@click.option(
+    "--type",
+    type=click.Choice(["dedicated"]),
+    help="Filter models by type (dedicated: models that support autoscaling)",
+)
 @click.pass_context
-def list(ctx: click.Context) -> None:
+def list(ctx: click.Context, type: str | None) -> None:
     """List models"""
     client: Together = ctx.obj
 
-    response = client.models.list()
+    response = client.models.list(dedicated=(type == "dedicated"))
 
     display_list = []
 

--- a/src/together/cli/api/models.py
+++ b/src/together/cli/api/models.py
@@ -18,7 +18,7 @@ def models(ctx: click.Context) -> None:
 @click.option(
     "--type",
     type=click.Choice(["dedicated"]),
-    help="Filter models by type (dedicated: models that support autoscaling)",
+    help="Filter models by type (dedicated: models that can be deployed as dedicated endpoints)",
 )
 @click.option(
     "--json",

--- a/src/together/cli/api/models.py
+++ b/src/together/cli/api/models.py
@@ -33,15 +33,15 @@ def list(ctx: click.Context, type: str | None) -> None:
     for model in response:
         display_list.append(
             {
-                "ID": "\n".join(wrap(model.id or "", width=30)),
-                "Name": "\n".join(wrap(model.display_name or "", width=30)),
+                "ID": model.id,
+                "Name": model.display_name,
                 "Organization": model.organization,
                 "Type": model.type,
                 "Context Length": model.context_length,
-                "License": "\n".join(wrap(model.license or "", width=30)),
+                "License": model.license,
                 "Input per 1M token": model.pricing.input,
                 "Output per 1M token": model.pricing.output,
             }
         )
 
-    click.echo(tabulate(display_list, headers="keys", tablefmt="grid"))
+    click.echo(tabulate(display_list, headers="keys", tablefmt="plain"))

--- a/src/together/resources/endpoints.py
+++ b/src/together/resources/endpoints.py
@@ -59,6 +59,7 @@ class Endpoints:
         disable_prompt_cache: bool = False,
         disable_speculative_decoding: bool = False,
         state: Literal["STARTED", "STOPPED"] = "STARTED",
+        inactive_timeout: Optional[int] = None,
     ) -> DedicatedEndpoint:
         """
         Create a new dedicated endpoint.
@@ -72,6 +73,7 @@ class Endpoints:
             disable_prompt_cache (bool, optional): Whether to disable the prompt cache. Defaults to False.
             disable_speculative_decoding (bool, optional): Whether to disable speculative decoding. Defaults to False.
             state (str, optional): The desired state of the endpoint. Defaults to "STARTED".
+            inactive_timeout (int, optional): The number of minutes of inactivity after which the endpoint will be automatically stopped. Set to 0 to disable automatic timeout.
 
         Returns:
             DedicatedEndpoint: Object containing endpoint information
@@ -80,7 +82,7 @@ class Endpoints:
             client=self._client,
         )
 
-        data: Dict[str, Union[str, bool, Dict[str, int]]] = {
+        data: Dict[str, Union[str, bool, Dict[str, int], int]] = {
             "model": model,
             "hardware": hardware,
             "autoscaling": {
@@ -94,6 +96,9 @@ class Endpoints:
 
         if display_name is not None:
             data["display_name"] = display_name
+
+        if inactive_timeout is not None:
+            data["inactive_timeout"] = inactive_timeout
 
         response, _, _ = requestor.request(
             options=TogetherRequest(
@@ -161,6 +166,7 @@ class Endpoints:
         max_replicas: Optional[int] = None,
         state: Optional[Literal["STARTED", "STOPPED"]] = None,
         display_name: Optional[str] = None,
+        inactive_timeout: Optional[int] = None,
     ) -> DedicatedEndpoint:
         """
         Update an endpoint's configuration.
@@ -171,6 +177,7 @@ class Endpoints:
             max_replicas (int, optional): The maximum number of replicas to scale up to
             state (str, optional): The desired state of the endpoint ("STARTED" or "STOPPED")
             display_name (str, optional): A human-readable name for the endpoint
+            inactive_timeout (int, optional): The number of minutes of inactivity after which the endpoint will be automatically stopped. Set to 0 to disable automatic timeout.
 
         Returns:
             DedicatedEndpoint: Object containing endpoint information
@@ -179,7 +186,7 @@ class Endpoints:
             client=self._client,
         )
 
-        data: Dict[str, Union[str, Dict[str, int]]] = {}
+        data: Dict[str, Union[str, Dict[str, int], int]] = {}
 
         if min_replicas is not None or max_replicas is not None:
             current_min = min_replicas
@@ -199,6 +206,9 @@ class Endpoints:
 
         if display_name is not None:
             data["display_name"] = display_name
+
+        if inactive_timeout is not None:
+            data["inactive_timeout"] = inactive_timeout
 
         response, _, _ = requestor.request(
             options=TogetherRequest(
@@ -297,6 +307,7 @@ class AsyncEndpoints:
         disable_prompt_cache: bool = False,
         disable_speculative_decoding: bool = False,
         state: Literal["STARTED", "STOPPED"] = "STARTED",
+        inactive_timeout: Optional[int] = None,
     ) -> DedicatedEndpoint:
         """
         Create a new dedicated endpoint.
@@ -310,6 +321,7 @@ class AsyncEndpoints:
             disable_prompt_cache (bool, optional): Whether to disable the prompt cache. Defaults to False.
             disable_speculative_decoding (bool, optional): Whether to disable speculative decoding. Defaults to False.
             state (str, optional): The desired state of the endpoint. Defaults to "STARTED".
+            inactive_timeout (int, optional): The number of minutes of inactivity after which the endpoint will be automatically stopped. Set to 0 to disable automatic timeout.
 
         Returns:
             DedicatedEndpoint: Object containing endpoint information
@@ -318,7 +330,7 @@ class AsyncEndpoints:
             client=self._client,
         )
 
-        data: Dict[str, Union[str, bool, Dict[str, int]]] = {
+        data: Dict[str, Union[str, bool, Dict[str, int], int]] = {
             "model": model,
             "hardware": hardware,
             "autoscaling": {
@@ -332,6 +344,9 @@ class AsyncEndpoints:
 
         if display_name is not None:
             data["display_name"] = display_name
+
+        if inactive_timeout is not None:
+            data["inactive_timeout"] = inactive_timeout
 
         response, _, _ = await requestor.arequest(
             options=TogetherRequest(
@@ -399,6 +414,7 @@ class AsyncEndpoints:
         max_replicas: Optional[int] = None,
         state: Optional[Literal["STARTED", "STOPPED"]] = None,
         display_name: Optional[str] = None,
+        inactive_timeout: Optional[int] = None,
     ) -> DedicatedEndpoint:
         """
         Update an endpoint's configuration.
@@ -409,6 +425,7 @@ class AsyncEndpoints:
             max_replicas (int, optional): The maximum number of replicas to scale up to
             state (str, optional): The desired state of the endpoint ("STARTED" or "STOPPED")
             display_name (str, optional): A human-readable name for the endpoint
+            inactive_timeout (int, optional): The number of minutes of inactivity after which the endpoint will be automatically stopped. Set to 0 to disable automatic timeout.
 
         Returns:
             DedicatedEndpoint: Object containing endpoint information
@@ -417,7 +434,7 @@ class AsyncEndpoints:
             client=self._client,
         )
 
-        data: Dict[str, Union[str, Dict[str, int]]] = {}
+        data: Dict[str, Union[str, Dict[str, int], int]] = {}
 
         if min_replicas is not None or max_replicas is not None:
             current_min = min_replicas
@@ -437,6 +454,9 @@ class AsyncEndpoints:
 
         if display_name is not None:
             data["display_name"] = display_name
+
+        if inactive_timeout is not None:
+            data["inactive_timeout"] = inactive_timeout
 
         response, _, _ = await requestor.arequest(
             options=TogetherRequest(

--- a/src/together/resources/models.py
+++ b/src/together/resources/models.py
@@ -81,6 +81,8 @@ class Models(ModelsBase):
 
             models = self._filter_dedicated_models(models, dedicated_response)
 
+        models.sort(key=lambda x: x.id.lower())
+
         return models
 
 
@@ -126,5 +128,7 @@ class AsyncModels(ModelsBase):
             )
 
             models = self._filter_dedicated_models(models, dedicated_response)
+
+        models.sort(key=lambda x: x.id.lower())
 
         return models

--- a/src/together/resources/models.py
+++ b/src/together/resources/models.py
@@ -11,20 +11,47 @@ from together.types import (
 )
 
 
-class Models:
+class ModelsBase:
     def __init__(self, client: TogetherClient) -> None:
         self._client = client
 
+    def _filter_dedicated_models(
+        self, models: List[ModelObject], dedicated_response: TogetherResponse
+    ) -> List[ModelObject]:
+        """
+        Filter models based on dedicated model response.
+
+        Args:
+            models (List[ModelObject]): List of all models
+            dedicated_response (TogetherResponse): Response from autoscale models endpoint
+
+        Returns:
+            List[ModelObject]: Filtered list of models
+        """
+        assert isinstance(dedicated_response.data, list)
+
+        # Create a set of dedicated model names for efficient lookup
+        dedicated_model_names = {model["name"] for model in dedicated_response.data}
+
+        # Filter models to only include those in dedicated_model_names
+        # Note: The model.id from ModelObject matches the name field in the autoscale response
+        return [model for model in models if model.id in dedicated_model_names]
+
+
+class Models(ModelsBase):
     def list(
         self,
+        dedicated: bool = False,
     ) -> List[ModelObject]:
         """
         Method to return list of models on the API
 
+        Args:
+            dedicated (bool, optional): If True, returns only dedicated models. Defaults to False.
+
         Returns:
             List[ModelObject]: List of model objects
         """
-
         requestor = api_requestor.APIRequestor(
             client=self._client,
         )
@@ -40,23 +67,37 @@ class Models:
         assert isinstance(response, TogetherResponse)
         assert isinstance(response.data, list)
 
-        return [ModelObject(**model) for model in response.data]
+        models = [ModelObject(**model) for model in response.data]
+
+        if dedicated:
+            # Get dedicated models
+            dedicated_response, _, _ = requestor.request(
+                options=TogetherRequest(
+                    method="GET",
+                    url="autoscale/models",
+                ),
+                stream=False,
+            )
+
+            models = self._filter_dedicated_models(models, dedicated_response)
+
+        return models
 
 
-class AsyncModels:
-    def __init__(self, client: TogetherClient) -> None:
-        self._client = client
-
+class AsyncModels(ModelsBase):
     async def list(
         self,
+        dedicated: bool = False,
     ) -> List[ModelObject]:
         """
         Async method to return list of models on API
 
+        Args:
+            dedicated (bool, optional): If True, returns only dedicated models. Defaults to False.
+
         Returns:
             List[ModelObject]: List of model objects
         """
-
         requestor = api_requestor.APIRequestor(
             client=self._client,
         )
@@ -72,4 +113,18 @@ class AsyncModels:
         assert isinstance(response, TogetherResponse)
         assert isinstance(response.data, list)
 
-        return [ModelObject(**model) for model in response.data]
+        models = [ModelObject(**model) for model in response.data]
+
+        if dedicated:
+            # Get dedicated models
+            dedicated_response, _, _ = await requestor.arequest(
+                options=TogetherRequest(
+                    method="GET",
+                    url="autoscale/models",
+                ),
+                stream=False,
+            )
+
+            models = self._filter_dedicated_models(models, dedicated_response)
+
+        return models


### PR DESCRIPTION
## Models list changes

Adds support for 

```
together models list --type=dedicated
```

Also changes the table to use a simple table, which has similar semantics to docker. This way, users can more easily parse its output by doing, for example, `together models list --type=dedicated | wc -l` or splitting out ID. Also added a `--json` option.

## Inactivity Timeout support

```
together endpoints create --model mistralai/Mixtral-8x7B-Instruct-v0.1 --inactive-timeout 2 --gpu h100 --gpu-count 2
```

Fixes https://linear.app/together-ai/issue/ENG-21594/list-dedicated-models
Fixes https://linear.app/together-ai/issue/ENG-23176/add-autoshutdown-to-public-api-docs-open-api-specs