### PR TITLE
Danwaters/eng 21477 ml eng support support google colab secret for together api

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ build-backend = "poetry.masonry.api"
 
 [tool.poetry]
 name = "together"
-version = "1.4.4"
+version = "1.4.5"
 authors = [
     "Together AI <support@together.ai>"
 ]

--- a/src/together/client.py
+++ b/src/together/client.py
@@ -9,6 +9,7 @@ from together.constants import BASE_URL, MAX_RETRIES, TIMEOUT_SECS
 from together.error import AuthenticationError
 from together.types import TogetherClient
 from together.utils import enforce_trailing_slash
+from together.utils.api_helpers import get_google_colab_secret
 
 
 class Together:
@@ -45,22 +46,8 @@ class Together:
         if not api_key:
             api_key = os.environ.get("TOGETHER_API_KEY")
 
-        # If running in Google Colab, check notebook secrets
         if not api_key and "google.colab" in sys.modules:
-            if TYPE_CHECKING:
-                from google.colab import userdata  # type: ignore
-            else:
-                from google.colab import userdata
-            try:
-                api_key = userdata.get("TOGETHER_API_KEY")
-            except userdata.NotebookAccessError:
-                print(
-                    "The TOGETHER_API_KEY Colab secret was found, but notebook access is disabled. Please enable notebook "
-                    "access for the secret."
-                )
-            except userdata.SecretNotFoundError:
-                # warn and carry on
-                print("Colab: No Google Colab secret named TOGETHER_API_KEY was found.")
+            api_key = get_google_colab_secret("TOGETHER_API_KEY")
 
         if not api_key:
             raise AuthenticationError(
@@ -134,6 +121,9 @@ class AsyncTogether:
         # get api key
         if not api_key:
             api_key = os.environ.get("TOGETHER_API_KEY")
+
+        if not api_key and "google.colab" in sys.modules:
+            api_key = get_google_colab_secret("TOGETHER_API_KEY")
 
         if not api_key:
             raise AuthenticationError(

--- a/tests/integration/constants.py
+++ b/tests/integration/constants.py
@@ -1,5 +1,5 @@
 completion_test_model_list = [
-    "mistralai/Mistral-7B-v0.1",
+    "meta-llama/Meta-Llama-3.1-8B-Instruct-Turbo",
 ]
 chat_test_model_list = []
 embedding_test_model_list = []

--- a/tests/integration/resources/test_completion.py
+++ b/tests/integration/resources/test_completion.py
@@ -213,7 +213,7 @@ class TestTogetherCompletion:
         product(
             completion_test_model_list,
             completion_prompt_list,
-            [35000, 40000, 50000],
+            [200000, 400000, 500000],
         ),
     )
     def test_high_max_tokens(


### PR DESCRIPTION
*Have you read the [Contributing Guidelines](https://github.com/togethercomputer/together/blob/main/CONTRIBUTING.md)?* Yes

Issue #ENG-21477

## Describe your changes

* Implement support for Google Colab Secrets feature
* Users can now set `TOGETHER_API_KEY` in Colab's Secrets panel to instantiate the `Together` and `AsyncTogether` clients without hard-coding API keys
* Makes sharing of examples using Together's library even easier

<img width="475" alt="image" src="https://github.com/user-attachments/assets/07f3dd10-9548-42d5-8f11-99f0295c8851" />

