### PR TITLE
Make it possible to exclude pyarrow dep

### DIFF
--- a/src/together/utils/files.py
+++ b/src/together/utils/files.py
@@ -6,7 +6,6 @@ from pathlib import Path
 from traceback import format_exc
 from typing import Any, Dict, List
 
-from pyarrow import ArrowInvalid, parquet
 
 from together.constants import (
     MAX_FILE_SIZE_GB,
@@ -372,6 +371,8 @@ def _check_jsonl(file: Path) -> Dict[str, Any]:
 
 
 def _check_parquet(file: Path) -> Dict[str, Any]:
+    # in method import - this allows client to exclude the pyarrow dep if they don't need it. Saved ~80MB and more compatible with older systems.
+    from pyarrow import ArrowInvalid, parquet
     report_dict: Dict[str, Any] = {}
 
     try:


### PR DESCRIPTION
Fixes https://github.com/togethercomputer/together-python/issues/274

pyarrow has a few issues:

 - it's huge: about 100MB uncompressed
 - It's not compatible with all systems (Intel Macs)

This change allows client to exclude the pyarrow dep if they don't need it. It's only used for parquet file validation, which isn't needed by all users.

Note: I'm not removing the dependency- just making it run-time import. It still works as expected for all users, unless users go out of their way to manually exclude this dependency. 

*Have you read the [Contributing Guidelines](https://github.com/togethercomputer/together/blob/main/CONTRIBUTING.md)?*
yes

Issue # https://github.com/togethercomputer/together-python/issues/274

