### PR TITLE
Fix GitHub workflows after removing support for 3.9

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/devcontainers/python:3.9
+FROM mcr.microsoft.com/devcontainers/python:3.10
 
 ENV PYTHONUNBUFFERED 1
 

--- a/.github/workflows/_integration_tests.yml
+++ b/.github/workflows/_integration_tests.yml
@@ -3,13 +3,13 @@ name: integration-tests
 on:
   push:
     branches: [ main ]
-    paths:
-      - "**.py"
+    paths-ignore:
+      - "**.md"
 
   pull_request:
     branches: [ main ]
-    paths:
-      - "**.py"
+    paths-ignore:
+      - "**.md"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
@@ -24,7 +24,6 @@ jobs:
     strategy:
       matrix:
         python-version:
-          - "3.9"
           - "3.10"
           - "3.11"
           - "3.12"

--- a/.github/workflows/_tests.yml
+++ b/.github/workflows/_tests.yml
@@ -3,13 +3,13 @@ name: unit-tests
 on:
   push:
     branches: [ main ]
-    paths:
-      - "**.py"
+    paths-ignore:
+      - "**.md"
 
   pull_request:
     branches: [ main ]
-    paths:
-      - "**.py"
+    paths-ignore:
+      - "**.md"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
@@ -24,7 +24,6 @@ jobs:
     strategy:
       matrix:
         python-version:
-          - "3.9"
           - "3.10"
           - "3.11"
           - "3.12"

--- a/.github/workflows/check_code_quality.yml
+++ b/.github/workflows/check_code_quality.yml
@@ -3,13 +3,9 @@ name: pre-commit
 on:
   push:
     branches: [ main ]
-    paths:
-      - "**.py"
 
   pull_request:
     branches: [ main ]
-    paths:
-      - "**.py"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}


### PR DESCRIPTION
## Describe your changes

This PR fixes GH workflows after the recent deletion of support for Python == 3.9. It also changes the condition for the tests to run on: for any code-related change, tests should run and check changes.