### PR TITLE
Fix model_name requirements

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ build-backend = "poetry.masonry.api"
 
 [tool.poetry]
 name = "together"
-version = "1.5.0"
+version = "1.5.1"
 authors = [
     "Together AI <support@together.ai>"
 ]

--- a/src/together/cli/api/finetune.py
+++ b/src/together/cli/api/finetune.py
@@ -60,7 +60,7 @@ def fine_tuning(ctx: click.Context) -> None:
 @click.option(
     "--training-file", type=str, required=True, help="Training file ID from Files API"
 )
-@click.option("--model", type=str, required=True, help="Base model name")
+@click.option("--model", type=str, help="Base model name")
 @click.option("--n-epochs", type=int, default=1, help="Number of epochs to train for")
 @click.option(
     "--validation-file", type=str, default="", help="Validation file ID from Files API"
@@ -214,8 +214,15 @@ def create(
         from_checkpoint=from_checkpoint,
     )
 
+    if model is None and from_checkpoint is None:
+        raise click.BadParameter("You must specify either a model or a checkpoint")
+
+    model_name = model
+    if from_checkpoint is not None:
+        model_name = from_checkpoint.split(":")[0]
+
     model_limits: FinetuneTrainingLimits = client.fine_tuning.get_model_limits(
-        model=model
+        model=model_name
     )
 
     if lora:

--- a/src/together/resources/finetune.py
+++ b/src/together/resources/finetune.py
@@ -77,6 +77,11 @@ def createFinetuneRequest(
     from_checkpoint: str | None = None,
 ) -> FinetuneRequest:
 
+    if model is not None and from_checkpoint is not None:
+        raise ValueError(
+            "You must specify either a model or a checkpoint to start a job from, not both"
+        )
+
     if batch_size == "max":
         log_warn_once(
             "Starting from together>=1.3.0, "

--- a/src/together/resources/finetune.py
+++ b/src/together/resources/finetune.py
@@ -50,7 +50,7 @@ AVAILABLE_TRAINING_METHODS = {
 def createFinetuneRequest(
     model_limits: FinetuneTrainingLimits,
     training_file: str,
-    model: str,
+    model: str | None = None,
     n_epochs: int = 1,
     validation_file: str | None = "",
     n_evals: int | None = 0,
@@ -237,7 +237,7 @@ class FineTuning:
         self,
         *,
         training_file: str,
-        model: str,
+        model: str | None = None,
         n_epochs: int = 1,
         validation_file: str | None = "",
         n_evals: int | None = 0,
@@ -270,7 +270,7 @@ class FineTuning:
 
         Args:
             training_file (str): File-ID of a file uploaded to the Together API
-            model (str): Name of the base model to run fine-tune job on
+            model (str, optional): Name of the base model to run fine-tune job on
             n_epochs (int, optional): Number of epochs for fine-tuning. Defaults to 1.
             validation file (str, optional): File ID of a file uploaded to the Together API for validation.
             n_evals (int, optional): Number of evaluation loops to run. Defaults to 0.
@@ -320,12 +320,24 @@ class FineTuning:
             FinetuneResponse: Object containing information about fine-tuning job.
         """
 
+        if model is None and from_checkpoint is None:
+            raise ValueError("You must specify either a model or a checkpoint")
+
         requestor = api_requestor.APIRequestor(
             client=self._client,
         )
 
         if model_limits is None:
-            model_limits = self.get_model_limits(model=model)
+            # mypy doesn't understand that model or from_checkpoint is not None
+            if model is not None:
+                model_name = model
+            elif from_checkpoint is not None:
+                model_name = from_checkpoint.split(":")[0]
+            else:
+                # this branch is unreachable, but mypy doesn't know that
+                pass
+            model_limits = self.get_model_limits(model=model_name)
+
         finetune_request = createFinetuneRequest(
             model_limits=model_limits,
             training_file=training_file,
@@ -610,7 +622,7 @@ class AsyncFineTuning:
         self,
         *,
         training_file: str,
-        model: str,
+        model: str | None = None,
         n_epochs: int = 1,
         validation_file: str | None = "",
         n_evals: int | None = 0,
@@ -643,7 +655,7 @@ class AsyncFineTuning:
 
         Args:
             training_file (str): File-ID of a file uploaded to the Together API
-            model (str): Name of the base model to run fine-tune job on
+            model (str, optional): Name of the base model to run fine-tune job on
             n_epochs (int, optional): Number of epochs for fine-tuning. Defaults to 1.
             validation file (str, optional): File ID of a file uploaded to the Together API for validation.
             n_evals (int, optional): Number of evaluation loops to run. Defaults to 0.
@@ -693,12 +705,23 @@ class AsyncFineTuning:
             FinetuneResponse: Object containing information about fine-tuning job.
         """
 
+        if model is None and from_checkpoint is None:
+            raise ValueError("You must specify either a model or a checkpoint")
+
         requestor = api_requestor.APIRequestor(
             client=self._client,
         )
 
         if model_limits is None:
-            model_limits = await self.get_model_limits(model=model)
+            # mypy doesn't understand that model or from_checkpoint is not None
+            if model is not None:
+                model_name = model
+            elif from_checkpoint is not None:
+                model_name = from_checkpoint.split(":")[0]
+            else:
+                # this branch is unreachable, but mypy doesn't know that
+                pass
+            model_limits = await self.get_model_limits(model=model_name)
 
         finetune_request = createFinetuneRequest(
             model_limits=model_limits,


### PR DESCRIPTION
Issue # ENG-18831

## Describe your changes

This PR removes the "require" flag from the `model` field in the fine-tuning create command if the `from_checkpoint` field is set. The latter is enough to derive the model limits and settings required for fine-tuning.
