### PR TITLE
Add more information from response object to APIError during file upload

### DIFF
--- a/src/together/filemanager.py
+++ b/src/together/filemanager.py
@@ -378,7 +378,8 @@ class UploadManager:
 
             if not callback_response.status_code == 200:
                 raise APIError(
-                    f"Error code: {callback_response.status_code} - Failed to process uploaded file"
+                    f"Error during file upload: {callback_response.content.decode()}, headers: {callback_response.headers}",
+                    http_status=callback_response.status_code,
                 )
 
             response = self.callback(f"{url}/{file_id}/preprocess")


### PR DESCRIPTION
Not much information is currently shared when there is an error during file upload. Adding more info from response object.

I copied the way the APIError was created here:
https://github.com/togethercomputer/together-python/blob/64d0067ec62f9efeb870ed6f2c1c0b59f6424927/src/together/filemanager.py#L259-L262

Fixes #ENG-25010
