### PR TITLE
fix(ft): download checkpoint query param

### DIFF
--- a/src/together/resources/finetune.py
+++ b/src/together/resources/finetune.py
@@ -600,7 +600,7 @@ class FineTuning:
                 raise ValueError(
                     "Only DEFAULT checkpoint type is allowed for FullTrainingType"
                 )
-            url += "&checkpoint=modelOutputPath"
+            url += "&checkpoint=model_output_path"
         elif isinstance(ft_job.training_type, LoRATrainingType):
             if checkpoint_type == DownloadCheckpointType.DEFAULT:
                 checkpoint_type = DownloadCheckpointType.MERGED


### PR DESCRIPTION
The server route for downloading the checkpoints supports both camelCase and snake_case but we recently changed together-web to use `model_output_path` so I thought it would be nice to keep it consistent in here as well

Reference for together-web change: https://github.com/togethercomputer/together-web/commit/0ed8e324fea8dd65af8ae2e32e91a3c9618471d1#diff-6d4e8f04c6db043f607f4f4442aa889734124199add080af1ae8628ea93633bc