### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/upload-to-pypi.yml
+++ b/.github/workflows/upload-to-pypi.yml
@@ -4,6 +4,10 @@ on:
   release:
     types: [published]
 
+permissions:
+  contents: read
+  packages: write
+
 env:
   POETRY_VERSION: "2.1.1"
 


### PR DESCRIPTION
Potential fix for [https://github.com/togethercomputer/together-python/security/code-scanning/5](https://github.com/togethercomputer/together-python/security/code-scanning/5)

To fix the issue, add a `permissions` block at the root of the workflow to explicitly define the minimal permissions required. Based on the workflow's functionality, it primarily interacts with repository contents and publishes to PyPI. Therefore, the `contents: read` permission is sufficient for most steps, while the `packages: write` permission is required for the publishing step.

The `permissions` block should be added at the root level to apply to all jobs in the workflow. If any job requires additional permissions, they can be specified within that job's `permissions` block.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
