### PR TITLE
Adding transcribe to models.py to resolve error with getmodels call

### DIFF
--- a/src/together/types/models.py
+++ b/src/together/types/models.py
@@ -16,6 +16,7 @@ class ModelType(str, Enum):
     MODERATION = "moderation"
     RERANK = "rerank"
     AUDIO = "audio"
+    TRANSCRIBE = "transcribe"
 
 
 class PricingObject(BaseModel):


### PR DESCRIPTION
*Have you read the [Contributing Guidelines](https://github.com/togethercomputer/together/blob/main/CONTRIBUTING.md)?*

Issue #ENG-33523

## Describe your changes

*Clearly and concisely describe what's in this pull request. Include screenshots, if necessary.*

Adding "TRANSCRIBE=transcribe" to "src/together/types/models.py" under "class ModelType(str, Enum):"

This is to resolve a current error with our "client.models.list()" call currently in the Python SDK. This currently results in the following error:
`Input should be 'chat', 'language', 'code', 'image', 'embedding', 'moderation', 'rerank' or 'audio' [type=enum, input_value='transcribe', input_type=str]
    For further information visit https://errors.pydantic.dev/2.10/v/enum`
