### PR TITLE
remove assert for 0 file size

### DIFF
--- a/src/together/filemanager.py
+++ b/src/together/filemanager.py
@@ -73,7 +73,6 @@ def _get_file_size(
         if len(range_parts) == 2:
             total_size_in_bytes = int(range_parts[1])
 
-
     return total_size_in_bytes
 
 
@@ -211,7 +210,6 @@ class DownloadManager:
 
                 if not fetch_metadata:
                     file_size = int(response.headers.get("content-length", 0))
-
 
                 with tqdm(
                     total=file_size,


### PR DESCRIPTION
Issue #

Remove assert on file size when downloading. Batch api may upload empty files. Empty files should not throw failed to retrieve assert as the file is successfully retrieved but happens to be empty.

## Describe your changes
Remove assert on file size

