### PR TITLE
Implement multipart upload

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,4 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+test_data/

--- a/src/together/constants.py
+++ b/src/together/constants.py
@@ -15,6 +15,20 @@ BASE_URL = "https://api.together.xyz/v1"
 DOWNLOAD_BLOCK_SIZE = 10 * 1024 * 1024  # 10 MB
 DISABLE_TQDM = False
 
+# Upload defaults
+MAX_CONCURRENT_PARTS = 4  # Maximum concurrent parts for multipart upload
+
+# Multipart upload constants
+MIN_PART_SIZE_MB = 5  # Minimum part size (S3 requirement)
+TARGET_PART_SIZE_MB = 100  # Target part size for optimal performance
+MAX_MULTIPART_PARTS = 250  # Maximum parts per upload (S3 limit)
+MULTIPART_UPLOAD_TIMEOUT = 300  # Timeout in seconds for uploading each part
+MULTIPART_THRESHOLD_GB = 5.0  # threshold for switching to multipart upload
+
+# maximum number of GB sized files we support finetuning for
+MAX_FILE_SIZE_GB = 25.0
+
+
 # Messages
 MISSING_API_KEY_MESSAGE = """TOGETHER_API_KEY not found.
 Please set it as an environment variable or set it as together.api_key
@@ -26,8 +40,6 @@ MIN_SAMPLES = 1
 # the number of bytes in a gigabyte, used to convert bytes to GB for readable comparison
 NUM_BYTES_IN_GB = 2**30
 
-# maximum number of GB sized files we support finetuning for
-MAX_FILE_SIZE_GB = 4.9
 
 # expected columns for Parquet files
 PARQUET_EXPECTED_COLUMNS = ["input_ids", "attention_mask", "labels"]

--- a/src/together/filemanager.py
+++ b/src/together/filemanager.py
@@ -526,13 +526,13 @@ class MultipartUploadManager:
 
                 with open(file, "rb") as f:
                     for part_info in parts:
-                        f.seek((part_info["part_number"] - 1) * part_size)
+                        f.seek((part_info["PartNumber"] - 1) * part_size)
                         part_data = f.read(part_size)
 
                         future = executor.submit(
                             self._upload_single_part, part_info, part_data
                         )
-                        future_to_part[future] = part_info["part_number"]
+                        future_to_part[future] = part_info["PartNumber"]
 
                 # Collect results
                 for future in as_completed(future_to_part):
@@ -553,16 +553,16 @@ class MultipartUploadManager:
         """Upload a single part and return ETag"""
 
         response = requests.put(
-            part_info["url"],
+            part_info["URL"],
             data=part_data,
-            headers=part_info.get("headers", {}),
+            headers=part_info.get("Headers", {}),
             timeout=MULTIPART_UPLOAD_TIMEOUT,
         )
         response.raise_for_status()
 
         etag = response.headers.get("ETag", "").strip('"')
         if not etag:
-            raise ResponseError(f"No ETag returned for part {part_info['part_number']}")
+            raise ResponseError(f"No ETag returned for part {part_info['PartNumber']}")
 
         return etag
 
@@ -591,7 +591,7 @@ class MultipartUploadManager:
             ),
         )
 
-        return FileResponse(**response.data["file"])
+        return FileResponse(**response.data.get("file", response.data))
 
     def _abort_upload(self, url: str, upload_id: str, file_id: str) -> None:
         """Abort the multipart upload"""

--- a/src/together/filemanager.py
+++ b/src/together/filemanager.py
@@ -569,7 +569,11 @@ class MultipartUploadManager:
         return etag
 
     def _complete_upload(
-        self, url: str, upload_id: str, file_id: str, completed_parts: List[Dict[str, Any]]
+        self,
+        url: str,
+        upload_id: str,
+        file_id: str,
+        completed_parts: List[Dict[str, Any]],
     ) -> FileResponse:
         """Complete the multipart upload"""
 

--- a/src/together/resources/files.py
+++ b/src/together/resources/files.py
@@ -48,8 +48,7 @@ class Files:
 
         assert isinstance(purpose, FilePurpose)
 
-        # Size-based routing: use multipart for files > 5GB
-        file_size = os.stat(file.as_posix()).st_size
+        file_size = os.stat(file).st_size
         file_size_gb = file_size / NUM_BYTES_IN_GB
 
         if file_size_gb > MULTIPART_THRESHOLD_GB:

--- a/src/together/types/files.py
+++ b/src/together/types/files.py
@@ -52,7 +52,7 @@ class FileResponse(BaseModel):
     """
 
     id: str
-    object: Literal[ObjectType.File]
+    object: str
     # created timestamp
     created_at: int | None = None
     type: FileType | None = None

--- a/src/together/utils/files.py
+++ b/src/together/utils/files.py
@@ -65,7 +65,7 @@ def check_file(
     else:
         report_dict["found"] = True
 
-    file_size = os.stat(file.as_posix()).st_size
+    file_size = os.stat(file).st_size
 
     if file_size > MAX_FILE_SIZE_GB * NUM_BYTES_IN_GB:
         report_dict["message"] = (

--- a/tests/unit/test_files_upload_routing.py
+++ b/tests/unit/test_files_upload_routing.py
@@ -29,248 +29,297 @@ class TestFilesUploadRouting:
             object=ObjectType.File,
             filename="test.jsonl",
             bytes=1024 * 1024,  # 1MB
-            purpose=FilePurpose.FineTune
+            purpose=FilePurpose.FineTune,
         )
 
-    @patch('together.resources.files.check_file')
-    @patch('together.resources.files.os.stat')
-    @patch('together.resources.files.UploadManager')
-    def test_small_file_uses_single_upload(self, mock_upload_manager_class, 
-                                          mock_stat, mock_check_file, 
-                                          files_resource, mock_file_response):
+    @patch("together.resources.files.check_file")
+    @patch("together.resources.files.os.stat")
+    @patch("together.resources.files.UploadManager")
+    def test_small_file_uses_single_upload(
+        self,
+        mock_upload_manager_class,
+        mock_stat,
+        mock_check_file,
+        files_resource,
+        mock_file_response,
+    ):
         """Test that files under 5GB use single-part upload"""
         # Setup - file size under threshold
         file_size = 3 * NUM_BYTES_IN_GB  # 3GB
         mock_stat.return_value.st_size = file_size
-        
+
         # Mock file validation
         mock_check_file.return_value = {"is_check_passed": True}
-        
+
         # Mock upload manager
         mock_upload_manager = Mock()
         mock_upload_manager.upload.return_value = mock_file_response
         mock_upload_manager_class.return_value = mock_upload_manager
-        
+
         # Test
         result = files_resource.upload(Path("test.jsonl"), purpose=FilePurpose.FineTune)
-        
+
         # Assertions
         assert result == mock_file_response
-        
+
         # Verify single-part upload was used
         mock_upload_manager_class.assert_called_once_with(files_resource._client)
         mock_upload_manager.upload.assert_called_once_with(
             "files", Path("test.jsonl"), purpose=FilePurpose.FineTune, redirect=True
         )
 
-    @patch('together.resources.files.check_file')
-    @patch('together.resources.files.os.stat')
-    @patch('together.resources.files.MultipartUploadManager')
-    def test_large_file_uses_multipart_upload(self, mock_multipart_manager_class,
-                                             mock_stat, mock_check_file,
-                                             files_resource, mock_file_response):
+    @patch("together.resources.files.check_file")
+    @patch("together.resources.files.os.stat")
+    @patch("together.resources.files.MultipartUploadManager")
+    def test_large_file_uses_multipart_upload(
+        self,
+        mock_multipart_manager_class,
+        mock_stat,
+        mock_check_file,
+        files_resource,
+        mock_file_response,
+    ):
         """Test that files over 5GB use multipart upload"""
         # Setup - file size over threshold
         file_size = 10 * NUM_BYTES_IN_GB  # 10GB
         mock_stat.return_value.st_size = file_size
-        
+
         # Mock file validation
         mock_check_file.return_value = {"is_check_passed": True}
-        
+
         # Mock multipart upload manager
         mock_multipart_manager = Mock()
         mock_multipart_manager.upload.return_value = mock_file_response
         mock_multipart_manager_class.return_value = mock_multipart_manager
-        
+
         # Test
         result = files_resource.upload(Path("test.jsonl"), purpose=FilePurpose.FineTune)
-        
+
         # Assertions
         assert result == mock_file_response
-        
+
         # Verify multipart upload was used
         mock_multipart_manager_class.assert_called_once_with(files_resource._client)
         mock_multipart_manager.upload.assert_called_once_with(
             "files", Path("test.jsonl"), FilePurpose.FineTune
         )
 
-    @patch('together.resources.files.check_file')
-    @patch('together.resources.files.os.stat')
-    @patch('together.resources.files.UploadManager')
-    def test_threshold_boundary_exactly_5gb(self, mock_upload_manager_class,
-                                           mock_stat, mock_check_file,
-                                           files_resource, mock_file_response):
+    @patch("together.resources.files.check_file")
+    @patch("together.resources.files.os.stat")
+    @patch("together.resources.files.UploadManager")
+    def test_threshold_boundary_exactly_5gb(
+        self,
+        mock_upload_manager_class,
+        mock_stat,
+        mock_check_file,
+        files_resource,
+        mock_file_response,
+    ):
         """Test routing behavior at exactly the 5GB threshold"""
         # Setup - file size exactly at threshold
         file_size = MULTIPART_THRESHOLD_GB * NUM_BYTES_IN_GB  # Exactly 5GB
         mock_stat.return_value.st_size = file_size
-        
+
         # Mock file validation
         mock_check_file.return_value = {"is_check_passed": True}
-        
+
         # Mock upload manager
         mock_upload_manager = Mock()
         mock_upload_manager.upload.return_value = mock_file_response
         mock_upload_manager_class.return_value = mock_upload_manager
-        
+
         # Test
         result = files_resource.upload(Path("test.jsonl"), purpose=FilePurpose.FineTune)
-        
+
         # Assertions - exactly at threshold should use single upload
         assert result == mock_file_response
         mock_upload_manager_class.assert_called_once()
 
-    @patch('together.resources.files.check_file')
-    @patch('together.resources.files.os.stat')
-    @patch('together.resources.files.MultipartUploadManager')
-    def test_just_over_threshold_uses_multipart(self, mock_multipart_manager_class,
-                                               mock_stat, mock_check_file,
-                                               files_resource, mock_file_response):
+    @patch("together.resources.files.check_file")
+    @patch("together.resources.files.os.stat")
+    @patch("together.resources.files.MultipartUploadManager")
+    def test_just_over_threshold_uses_multipart(
+        self,
+        mock_multipart_manager_class,
+        mock_stat,
+        mock_check_file,
+        files_resource,
+        mock_file_response,
+    ):
         """Test that files just over 5GB use multipart upload"""
         # Setup - file size just over threshold
         file_size = int((MULTIPART_THRESHOLD_GB + 0.1) * NUM_BYTES_IN_GB)  # 5.1GB
         mock_stat.return_value.st_size = file_size
-        
+
         # Mock file validation
         mock_check_file.return_value = {"is_check_passed": True}
-        
+
         # Mock multipart upload manager
         mock_multipart_manager = Mock()
         mock_multipart_manager.upload.return_value = mock_file_response
         mock_multipart_manager_class.return_value = mock_multipart_manager
-        
+
         # Test
         result = files_resource.upload(Path("test.jsonl"), purpose=FilePurpose.FineTune)
-        
+
         # Assertions - just over threshold should use multipart
         assert result == mock_file_response
         mock_multipart_manager_class.assert_called_once()
 
-    @patch('together.resources.files.check_file')
-    @patch('together.resources.files.os.stat')
-    def test_file_validation_still_works(self, mock_stat, mock_check_file, files_resource):
+    @patch("together.resources.files.check_file")
+    @patch("together.resources.files.os.stat")
+    def test_file_validation_still_works(
+        self, mock_stat, mock_check_file, files_resource
+    ):
         """Test that file validation is still performed regardless of routing"""
         # Setup - invalid file
         file_size = 1 * NUM_BYTES_IN_GB  # 1GB (small file)
         mock_stat.return_value.st_size = file_size
-        
+
         # Mock file validation failure
         mock_check_file.return_value = {
             "is_check_passed": False,
-            "message": "Invalid file format"
+            "message": "Invalid file format",
         }
-        
+
         # Test - should raise FileTypeError
         from together.error import FileTypeError
+
         with pytest.raises(FileTypeError, match="Invalid file format"):
-            files_resource.upload(Path("test.jsonl"), purpose=FilePurpose.FineTune, check=True)
-        
+            files_resource.upload(
+                Path("test.jsonl"), purpose=FilePurpose.FineTune, check=True
+            )
+
         # Verify validation was called
         mock_check_file.assert_called_once()
 
-    @patch('together.resources.files.check_file')
-    @patch('together.resources.files.os.stat')
-    @patch('together.resources.files.UploadManager')
-    def test_check_disabled_skips_validation(self, mock_upload_manager_class,
-                                            mock_stat, mock_check_file,
-                                            files_resource, mock_file_response):
+    @patch("together.resources.files.check_file")
+    @patch("together.resources.files.os.stat")
+    @patch("together.resources.files.UploadManager")
+    def test_check_disabled_skips_validation(
+        self,
+        mock_upload_manager_class,
+        mock_stat,
+        mock_check_file,
+        files_resource,
+        mock_file_response,
+    ):
         """Test that check=False skips file validation"""
         # Setup
         file_size = 1 * NUM_BYTES_IN_GB  # 1GB
         mock_stat.return_value.st_size = file_size
-        
+
         # Mock upload manager
         mock_upload_manager = Mock()
         mock_upload_manager.upload.return_value = mock_file_response
         mock_upload_manager_class.return_value = mock_upload_manager
-        
+
         # Test with check=False
-        result = files_resource.upload(Path("test.jsonl"), purpose=FilePurpose.FineTune, check=False)
-        
+        result = files_resource.upload(
+            Path("test.jsonl"), purpose=FilePurpose.FineTune, check=False
+        )
+
         # Assertions
         assert result == mock_file_response
         # Verify validation was NOT called
         mock_check_file.assert_not_called()
 
-    @patch('together.resources.files.check_file')
-    @patch('together.resources.files.os.stat')
-    @patch('together.resources.files.UploadManager')
-    def test_eval_purpose_skips_validation(self, mock_upload_manager_class,
-                                          mock_stat, mock_check_file,
-                                          files_resource, mock_file_response):
+    @patch("together.resources.files.check_file")
+    @patch("together.resources.files.os.stat")
+    @patch("together.resources.files.UploadManager")
+    def test_eval_purpose_skips_validation(
+        self,
+        mock_upload_manager_class,
+        mock_stat,
+        mock_check_file,
+        files_resource,
+        mock_file_response,
+    ):
         """Test that non-FineTune purposes skip validation"""
         # Setup
         file_size = 1 * NUM_BYTES_IN_GB  # 1GB
         mock_stat.return_value.st_size = file_size
-        
+
         # Mock upload manager
         mock_upload_manager = Mock()
         mock_upload_manager.upload.return_value = mock_file_response
         mock_upload_manager_class.return_value = mock_upload_manager
-        
+
         # Test with Eval purpose
-        result = files_resource.upload(Path("test.csv"), purpose=FilePurpose.Eval, check=True)
-        
+        result = files_resource.upload(
+            Path("test.csv"), purpose=FilePurpose.Eval, check=True
+        )
+
         # Assertions
         assert result == mock_file_response
         # Verify validation was NOT called (only FineTune purpose gets validated)
         mock_check_file.assert_not_called()
 
-    @patch('together.resources.files.check_file')
-    @patch('together.resources.files.os.stat')
-    @patch('together.resources.files.MultipartUploadManager')
-    def test_string_path_converted_to_path(self, mock_multipart_manager_class,
-                                          mock_stat, mock_check_file,
-                                          files_resource, mock_file_response):
+    @patch("together.resources.files.check_file")
+    @patch("together.resources.files.os.stat")
+    @patch("together.resources.files.MultipartUploadManager")
+    def test_string_path_converted_to_path(
+        self,
+        mock_multipart_manager_class,
+        mock_stat,
+        mock_check_file,
+        files_resource,
+        mock_file_response,
+    ):
         """Test that string file paths are converted to Path objects"""
         # Setup
         file_size = 10 * NUM_BYTES_IN_GB  # 10GB
         mock_stat.return_value.st_size = file_size
-        
+
         # Mock file validation
         mock_check_file.return_value = {"is_check_passed": True}
-        
+
         # Mock multipart upload manager
         mock_multipart_manager = Mock()
         mock_multipart_manager.upload.return_value = mock_file_response
         mock_multipart_manager_class.return_value = mock_multipart_manager
-        
+
         # Test with string path
         result = files_resource.upload("test.jsonl", purpose=FilePurpose.FineTune)
-        
+
         # Assertions
         assert result == mock_file_response
-        
+
         # Verify Path object was passed to upload manager
         call_args = mock_multipart_manager.upload.call_args[0]
         assert isinstance(call_args[1], Path)
         assert str(call_args[1]) == "test.jsonl"
 
-    @patch('together.resources.files.check_file')
-    @patch('together.resources.files.os.stat')
-    @patch('together.resources.files.UploadManager')
-    def test_string_purpose_converted_to_enum(self, mock_upload_manager_class,
-                                             mock_stat, mock_check_file,
-                                             files_resource, mock_file_response):
+    @patch("together.resources.files.check_file")
+    @patch("together.resources.files.os.stat")
+    @patch("together.resources.files.UploadManager")
+    def test_string_purpose_converted_to_enum(
+        self,
+        mock_upload_manager_class,
+        mock_stat,
+        mock_check_file,
+        files_resource,
+        mock_file_response,
+    ):
         """Test that string purposes are converted to FilePurpose enum"""
         # Setup
         file_size = 1 * NUM_BYTES_IN_GB  # 1GB
         mock_stat.return_value.st_size = file_size
-        
+
         # Mock file validation
         mock_check_file.return_value = {"is_check_passed": True}
-        
+
         # Mock upload manager
         mock_upload_manager = Mock()
         mock_upload_manager.upload.return_value = mock_file_response
         mock_upload_manager_class.return_value = mock_upload_manager
-        
+
         # Test with string purpose
         result = files_resource.upload(Path("test.jsonl"), purpose="fine-tune")
-        
+
         # Assertions
         assert result == mock_file_response
-        
+
         # Verify FilePurpose enum was passed to upload manager
         call_args = mock_upload_manager.upload.call_args[1]
         assert call_args["purpose"] == FilePurpose.FineTune

--- a/tests/unit/test_files_upload_routing.py
+++ b/tests/unit/test_files_upload_routing.py
@@ -1,0 +1,276 @@
+import pytest
+from unittest.mock import Mock, patch, MagicMock
+from pathlib import Path
+
+from together.resources.files import Files
+from together.types import FilePurpose, FileResponse
+from together.types.common import ObjectType
+from together.constants import MULTIPART_THRESHOLD_GB, NUM_BYTES_IN_GB
+
+
+class TestFilesUploadRouting:
+    """Test suite for Files.upload() size-based routing logic"""
+
+    @pytest.fixture
+    def mock_client(self):
+        """Create a mock TogetherClient"""
+        return Mock()
+
+    @pytest.fixture
+    def files_resource(self, mock_client):
+        """Create a Files resource instance with mock client"""
+        return Files(mock_client)
+
+    @pytest.fixture
+    def mock_file_response(self):
+        """Create a mock FileResponse for testing"""
+        return FileResponse(
+            id="test-file-id",
+            object=ObjectType.File,
+            filename="test.jsonl",
+            bytes=1024 * 1024,  # 1MB
+            purpose=FilePurpose.FineTune
+        )
+
+    @patch('together.resources.files.check_file')
+    @patch('together.resources.files.os.stat')
+    @patch('together.resources.files.UploadManager')
+    def test_small_file_uses_single_upload(self, mock_upload_manager_class, 
+                                          mock_stat, mock_check_file, 
+                                          files_resource, mock_file_response):
+        """Test that files under 5GB use single-part upload"""
+        # Setup - file size under threshold
+        file_size = 3 * NUM_BYTES_IN_GB  # 3GB
+        mock_stat.return_value.st_size = file_size
+        
+        # Mock file validation
+        mock_check_file.return_value = {"is_check_passed": True}
+        
+        # Mock upload manager
+        mock_upload_manager = Mock()
+        mock_upload_manager.upload.return_value = mock_file_response
+        mock_upload_manager_class.return_value = mock_upload_manager
+        
+        # Test
+        result = files_resource.upload(Path("test.jsonl"), purpose=FilePurpose.FineTune)
+        
+        # Assertions
+        assert result == mock_file_response
+        
+        # Verify single-part upload was used
+        mock_upload_manager_class.assert_called_once_with(files_resource._client)
+        mock_upload_manager.upload.assert_called_once_with(
+            "files", Path("test.jsonl"), purpose=FilePurpose.FineTune, redirect=True
+        )
+
+    @patch('together.resources.files.check_file')
+    @patch('together.resources.files.os.stat')
+    @patch('together.resources.files.MultipartUploadManager')
+    def test_large_file_uses_multipart_upload(self, mock_multipart_manager_class,
+                                             mock_stat, mock_check_file,
+                                             files_resource, mock_file_response):
+        """Test that files over 5GB use multipart upload"""
+        # Setup - file size over threshold
+        file_size = 10 * NUM_BYTES_IN_GB  # 10GB
+        mock_stat.return_value.st_size = file_size
+        
+        # Mock file validation
+        mock_check_file.return_value = {"is_check_passed": True}
+        
+        # Mock multipart upload manager
+        mock_multipart_manager = Mock()
+        mock_multipart_manager.upload.return_value = mock_file_response
+        mock_multipart_manager_class.return_value = mock_multipart_manager
+        
+        # Test
+        result = files_resource.upload(Path("test.jsonl"), purpose=FilePurpose.FineTune)
+        
+        # Assertions
+        assert result == mock_file_response
+        
+        # Verify multipart upload was used
+        mock_multipart_manager_class.assert_called_once_with(files_resource._client)
+        mock_multipart_manager.upload.assert_called_once_with(
+            "files", Path("test.jsonl"), FilePurpose.FineTune
+        )
+
+    @patch('together.resources.files.check_file')
+    @patch('together.resources.files.os.stat')
+    @patch('together.resources.files.UploadManager')
+    def test_threshold_boundary_exactly_5gb(self, mock_upload_manager_class,
+                                           mock_stat, mock_check_file,
+                                           files_resource, mock_file_response):
+        """Test routing behavior at exactly the 5GB threshold"""
+        # Setup - file size exactly at threshold
+        file_size = MULTIPART_THRESHOLD_GB * NUM_BYTES_IN_GB  # Exactly 5GB
+        mock_stat.return_value.st_size = file_size
+        
+        # Mock file validation
+        mock_check_file.return_value = {"is_check_passed": True}
+        
+        # Mock upload manager
+        mock_upload_manager = Mock()
+        mock_upload_manager.upload.return_value = mock_file_response
+        mock_upload_manager_class.return_value = mock_upload_manager
+        
+        # Test
+        result = files_resource.upload(Path("test.jsonl"), purpose=FilePurpose.FineTune)
+        
+        # Assertions - exactly at threshold should use single upload
+        assert result == mock_file_response
+        mock_upload_manager_class.assert_called_once()
+
+    @patch('together.resources.files.check_file')
+    @patch('together.resources.files.os.stat')
+    @patch('together.resources.files.MultipartUploadManager')
+    def test_just_over_threshold_uses_multipart(self, mock_multipart_manager_class,
+                                               mock_stat, mock_check_file,
+                                               files_resource, mock_file_response):
+        """Test that files just over 5GB use multipart upload"""
+        # Setup - file size just over threshold
+        file_size = int((MULTIPART_THRESHOLD_GB + 0.1) * NUM_BYTES_IN_GB)  # 5.1GB
+        mock_stat.return_value.st_size = file_size
+        
+        # Mock file validation
+        mock_check_file.return_value = {"is_check_passed": True}
+        
+        # Mock multipart upload manager
+        mock_multipart_manager = Mock()
+        mock_multipart_manager.upload.return_value = mock_file_response
+        mock_multipart_manager_class.return_value = mock_multipart_manager
+        
+        # Test
+        result = files_resource.upload(Path("test.jsonl"), purpose=FilePurpose.FineTune)
+        
+        # Assertions - just over threshold should use multipart
+        assert result == mock_file_response
+        mock_multipart_manager_class.assert_called_once()
+
+    @patch('together.resources.files.check_file')
+    @patch('together.resources.files.os.stat')
+    def test_file_validation_still_works(self, mock_stat, mock_check_file, files_resource):
+        """Test that file validation is still performed regardless of routing"""
+        # Setup - invalid file
+        file_size = 1 * NUM_BYTES_IN_GB  # 1GB (small file)
+        mock_stat.return_value.st_size = file_size
+        
+        # Mock file validation failure
+        mock_check_file.return_value = {
+            "is_check_passed": False,
+            "message": "Invalid file format"
+        }
+        
+        # Test - should raise FileTypeError
+        from together.error import FileTypeError
+        with pytest.raises(FileTypeError, match="Invalid file format"):
+            files_resource.upload(Path("test.jsonl"), purpose=FilePurpose.FineTune, check=True)
+        
+        # Verify validation was called
+        mock_check_file.assert_called_once()
+
+    @patch('together.resources.files.check_file')
+    @patch('together.resources.files.os.stat')
+    @patch('together.resources.files.UploadManager')
+    def test_check_disabled_skips_validation(self, mock_upload_manager_class,
+                                            mock_stat, mock_check_file,
+                                            files_resource, mock_file_response):
+        """Test that check=False skips file validation"""
+        # Setup
+        file_size = 1 * NUM_BYTES_IN_GB  # 1GB
+        mock_stat.return_value.st_size = file_size
+        
+        # Mock upload manager
+        mock_upload_manager = Mock()
+        mock_upload_manager.upload.return_value = mock_file_response
+        mock_upload_manager_class.return_value = mock_upload_manager
+        
+        # Test with check=False
+        result = files_resource.upload(Path("test.jsonl"), purpose=FilePurpose.FineTune, check=False)
+        
+        # Assertions
+        assert result == mock_file_response
+        # Verify validation was NOT called
+        mock_check_file.assert_not_called()
+
+    @patch('together.resources.files.check_file')
+    @patch('together.resources.files.os.stat')
+    @patch('together.resources.files.UploadManager')
+    def test_eval_purpose_skips_validation(self, mock_upload_manager_class,
+                                          mock_stat, mock_check_file,
+                                          files_resource, mock_file_response):
+        """Test that non-FineTune purposes skip validation"""
+        # Setup
+        file_size = 1 * NUM_BYTES_IN_GB  # 1GB
+        mock_stat.return_value.st_size = file_size
+        
+        # Mock upload manager
+        mock_upload_manager = Mock()
+        mock_upload_manager.upload.return_value = mock_file_response
+        mock_upload_manager_class.return_value = mock_upload_manager
+        
+        # Test with Eval purpose
+        result = files_resource.upload(Path("test.csv"), purpose=FilePurpose.Eval, check=True)
+        
+        # Assertions
+        assert result == mock_file_response
+        # Verify validation was NOT called (only FineTune purpose gets validated)
+        mock_check_file.assert_not_called()
+
+    @patch('together.resources.files.check_file')
+    @patch('together.resources.files.os.stat')
+    @patch('together.resources.files.MultipartUploadManager')
+    def test_string_path_converted_to_path(self, mock_multipart_manager_class,
+                                          mock_stat, mock_check_file,
+                                          files_resource, mock_file_response):
+        """Test that string file paths are converted to Path objects"""
+        # Setup
+        file_size = 10 * NUM_BYTES_IN_GB  # 10GB
+        mock_stat.return_value.st_size = file_size
+        
+        # Mock file validation
+        mock_check_file.return_value = {"is_check_passed": True}
+        
+        # Mock multipart upload manager
+        mock_multipart_manager = Mock()
+        mock_multipart_manager.upload.return_value = mock_file_response
+        mock_multipart_manager_class.return_value = mock_multipart_manager
+        
+        # Test with string path
+        result = files_resource.upload("test.jsonl", purpose=FilePurpose.FineTune)
+        
+        # Assertions
+        assert result == mock_file_response
+        
+        # Verify Path object was passed to upload manager
+        call_args = mock_multipart_manager.upload.call_args[0]
+        assert isinstance(call_args[1], Path)
+        assert str(call_args[1]) == "test.jsonl"
+
+    @patch('together.resources.files.check_file')
+    @patch('together.resources.files.os.stat')
+    @patch('together.resources.files.UploadManager')
+    def test_string_purpose_converted_to_enum(self, mock_upload_manager_class,
+                                             mock_stat, mock_check_file,
+                                             files_resource, mock_file_response):
+        """Test that string purposes are converted to FilePurpose enum"""
+        # Setup
+        file_size = 1 * NUM_BYTES_IN_GB  # 1GB
+        mock_stat.return_value.st_size = file_size
+        
+        # Mock file validation
+        mock_check_file.return_value = {"is_check_passed": True}
+        
+        # Mock upload manager
+        mock_upload_manager = Mock()
+        mock_upload_manager.upload.return_value = mock_file_response
+        mock_upload_manager_class.return_value = mock_upload_manager
+        
+        # Test with string purpose
+        result = files_resource.upload(Path("test.jsonl"), purpose="fine-tune")
+        
+        # Assertions
+        assert result == mock_file_response
+        
+        # Verify FilePurpose enum was passed to upload manager
+        call_args = mock_upload_manager.upload.call_args[1]
+        assert call_args["purpose"] == FilePurpose.FineTune

--- a/tests/unit/test_multipart_upload_manager.py
+++ b/tests/unit/test_multipart_upload_manager.py
@@ -60,7 +60,7 @@ class TestMultipartUploadManager:
         """Test part calculation for files smaller than target part size"""
         file_size = 50 * 1024 * 1024  # 50MB
         part_size, num_parts = manager._calculate_parts(file_size)
-        
+
         assert num_parts == 1
         assert part_size == file_size
 
@@ -68,10 +68,10 @@ class TestMultipartUploadManager:
         """Test part calculation for medium-sized files"""
         file_size = 500 * 1024 * 1024  # 500MB
         part_size, num_parts = manager._calculate_parts(file_size)
-        
+
         expected_parts = 5  # 500MB / 100MB = 5 parts
         expected_part_size = 100 * 1024 * 1024  # 100MB
-        
+
         assert num_parts == expected_parts
         assert part_size == expected_part_size
 
@@ -79,7 +79,7 @@ class TestMultipartUploadManager:
         """Test part calculation for large files that require scaling"""
         file_size = 50 * 1024 * 1024 * 1024  # 50GB
         part_size, num_parts = manager._calculate_parts(file_size)
-        
+
         # Should use maximum parts and scale part size
         assert num_parts == MAX_MULTIPART_PARTS  # 250
         expected_part_size = file_size // MAX_MULTIPART_PARTS
@@ -89,21 +89,23 @@ class TestMultipartUploadManager:
         """Test that minimum part size is respected"""
         # Create a scenario where calculated part size would be too small
         file_size = 1000 * 1024 * 1024  # 1GB
-        
-        with patch.object(manager, '_calculate_parts', wraps=manager._calculate_parts) as mock_calc:
+
+        with patch.object(
+            manager, "_calculate_parts", wraps=manager._calculate_parts
+        ) as mock_calc:
             part_size, num_parts = manager._calculate_parts(file_size)
-            
+
             # Ensure no part is smaller than minimum
             min_part_size = MIN_PART_SIZE_MB * 1024 * 1024
             assert part_size >= min_part_size
 
-    @patch('together.filemanager.api_requestor.APIRequestor')
+    @patch("together.filemanager.api_requestor.APIRequestor")
     def test_initiate_upload_success(self, mock_requestor_class, manager):
         """Test successful upload initiation"""
         # Setup mock
         mock_requestor = Mock()
         mock_requestor_class.return_value = mock_requestor
-        
+
         mock_response = TogetherResponse(
             data={
                 "upload_id": "test-upload-id",
@@ -112,36 +114,36 @@ class TestMultipartUploadManager:
                     {
                         "part_number": 1,
                         "url": "https://presigned-url-1.com",
-                        "headers": {"Authorization": "Bearer token"}
+                        "headers": {"Authorization": "Bearer token"},
                     }
-                ]
+                ],
             },
-            headers={}
+            headers={},
         )
         mock_requestor.request.return_value = (mock_response, None, None)
-        
+
         # Test
         result = manager._initiate_upload(
-            "test-url", 
-            Path("test.jsonl"), 
+            "test-url",
+            Path("test.jsonl"),
             1024 * 1024,  # 1MB
-            1, 
+            1,
             FilePurpose.FineTune,
-            "jsonl"
+            "jsonl",
         )
-        
+
         # Assertions
         assert result["upload_id"] == "test-upload-id"
         assert result["file_id"] == "test-file-id"
         assert len(result["parts"]) == 1
-        
+
         # Verify API call
         mock_requestor.request.assert_called_once()
         call_args = mock_requestor.request.call_args[1]["options"]
         assert call_args.method == "POST"
         assert call_args.url == "files/multipart/initiate"
 
-    @patch('together.filemanager.requests.put')
+    @patch("together.filemanager.requests.put")
     def test_upload_single_part_success(self, mock_put, manager):
         """Test successful single part upload"""
         # Setup mock response
@@ -149,29 +151,29 @@ class TestMultipartUploadManager:
         mock_response.headers = {"ETag": '"test-etag"'}
         mock_response.raise_for_status = Mock()
         mock_put.return_value = mock_response
-        
+
         # Test data
         part_info = {
             "part_number": 1,
             "url": "https://presigned-url.com",
-            "headers": {"Authorization": "Bearer token"}
+            "headers": {"Authorization": "Bearer token"},
         }
         part_data = b"test data"
-        
+
         # Test
         etag = manager._upload_single_part(part_info, part_data)
-        
+
         # Assertions
         assert etag == "test-etag"
         mock_put.assert_called_once_with(
             "https://presigned-url.com",
             data=part_data,
             headers={"Authorization": "Bearer token"},
-            timeout=MULTIPART_UPLOAD_TIMEOUT
+            timeout=MULTIPART_UPLOAD_TIMEOUT,
         )
         mock_response.raise_for_status.assert_called_once()
 
-    @patch('together.filemanager.requests.put')
+    @patch("together.filemanager.requests.put")
     def test_upload_single_part_no_etag_error(self, mock_put, manager):
         """Test error when no ETag is returned"""
         # Setup mock response without ETag
@@ -179,21 +181,21 @@ class TestMultipartUploadManager:
         mock_response.headers = {}
         mock_response.raise_for_status = Mock()
         mock_put.return_value = mock_response
-        
+
         part_info = {"part_number": 1, "url": "https://test.com", "headers": {}}
         part_data = b"test data"
-        
+
         # Test
         with pytest.raises(Exception, match="No ETag returned for part 1"):
             manager._upload_single_part(part_info, part_data)
 
-    @patch('together.filemanager.api_requestor.APIRequestor')
+    @patch("together.filemanager.api_requestor.APIRequestor")
     def test_complete_upload_success(self, mock_requestor_class, manager):
         """Test successful upload completion"""
         # Setup mock
         mock_requestor = Mock()
         mock_requestor_class.return_value = mock_requestor
-        
+
         mock_response = TogetherResponse(
             data={
                 "file": {
@@ -201,39 +203,41 @@ class TestMultipartUploadManager:
                     "object": "file",
                     "filename": "test.jsonl",
                     "bytes": 1024,
-                    "purpose": "fine-tune"
+                    "purpose": "fine-tune",
                 }
             },
-            headers={}
+            headers={},
         )
         mock_requestor.request.return_value = (mock_response, None, None)
-        
+
         # Test
         completed_parts = [{"part_number": 1, "etag": "test-etag"}]
-        result = manager._complete_upload("test-url", "upload-id", "file-id", completed_parts)
-        
+        result = manager._complete_upload(
+            "test-url", "upload-id", "file-id", completed_parts
+        )
+
         # Assertions
         assert isinstance(result, FileResponse)
         assert result.id == "test-file-id"
         assert result.filename == "test.jsonl"
-        
+
         # Verify API call
         mock_requestor.request.assert_called_once()
         call_args = mock_requestor.request.call_args[1]["options"]
         assert call_args.method == "POST"
         assert call_args.url == "files/multipart/complete"
 
-    @patch('together.filemanager.api_requestor.APIRequestor')
+    @patch("together.filemanager.api_requestor.APIRequestor")
     def test_abort_upload_success(self, mock_requestor_class, manager):
         """Test successful upload abort"""
         # Setup mock
         mock_requestor = Mock()
         mock_requestor_class.return_value = mock_requestor
         mock_requestor.request.return_value = (Mock(), None, None)
-        
+
         # Test
         manager._abort_upload("test-url", "upload-id", "file-id")
-        
+
         # Verify API call
         mock_requestor.request.assert_called_once()
         call_args = mock_requestor.request.call_args[1]["options"]
@@ -242,8 +246,8 @@ class TestMultipartUploadManager:
         assert call_args.params["upload_id"] == "upload-id"
         assert call_args.params["file_id"] == "file-id"
 
-    @patch('together.filemanager.ThreadPoolExecutor')
-    @patch('together.filemanager.open', create=True)
+    @patch("together.filemanager.ThreadPoolExecutor")
+    @patch("together.filemanager.open", create=True)
     def test_upload_parts_concurrent(self, mock_open, mock_executor_class, manager):
         """Test concurrent part upload functionality"""
         # Setup mocks
@@ -251,85 +255,97 @@ class TestMultipartUploadManager:
         mock_file.seek = Mock()
         mock_file.read.return_value = b"test data"
         mock_open.return_value.__enter__.return_value = mock_file
-        
+
         mock_executor = Mock()
         mock_executor_class.return_value.__enter__.return_value = mock_executor
-        
+
         # Mock futures
         mock_future1 = Mock()
         mock_future1.result.return_value = "etag1"
         mock_future2 = Mock()
         mock_future2.result.return_value = "etag2"
-        
+
         mock_executor.submit.side_effect = [mock_future1, mock_future2]
-        
+
         # Mock as_completed
-        with patch('together.filemanager.as_completed', return_value=[mock_future1, mock_future2]):
+        with patch(
+            "together.filemanager.as_completed",
+            return_value=[mock_future1, mock_future2],
+        ):
             upload_info = {
                 "parts": [
                     {"part_number": 1, "url": "url1", "headers": {}},
-                    {"part_number": 2, "url": "url2", "headers": {}}
+                    {"part_number": 2, "url": "url2", "headers": {}},
                 ]
             }
-            
+
             # Test
-            result = manager._upload_parts_concurrent(Path("test.jsonl"), upload_info, 1024)
-            
+            result = manager._upload_parts_concurrent(
+                Path("test.jsonl"), upload_info, 1024
+            )
+
             # Assertions
             assert len(result) == 2
             assert result[0]["part_number"] == 1
             assert result[0]["etag"] == "etag1"
             assert result[1]["part_number"] == 2
             assert result[1]["etag"] == "etag2"
-            
+
             # Verify executor was used
             assert mock_executor.submit.call_count == 2
 
-    @patch('together.filemanager.os.stat')
+    @patch("together.filemanager.os.stat")
     def test_file_size_exceeds_limit_raises_error(self, mock_stat, manager):
         """Test that files exceeding size limit raise FileTypeError with clear message"""
         # Setup - file size over limit
         file_size = int((MAX_FILE_SIZE_GB + 1) * NUM_BYTES_IN_GB)  # 26GB
         mock_stat.return_value.st_size = file_size
-        
+
         # Should raise FileTypeError with descriptive message
         with pytest.raises(FileTypeError) as exc_info:
             manager.upload("test-url", Path("test.jsonl"), FilePurpose.FineTune)
-        
+
         error_message = str(exc_info.value)
         assert "26.0GB exceeds maximum supported size of 25.0GB" in error_message
 
-    @patch.object(MultipartUploadManager, '_initiate_upload')
-    @patch.object(MultipartUploadManager, '_upload_parts_concurrent')
-    @patch.object(MultipartUploadManager, '_complete_upload')
-    @patch.object(MultipartUploadManager, '_abort_upload')
-    @patch('together.filemanager.os.stat')
-    def test_upload_success_flow(self, mock_stat, mock_abort, mock_complete, 
-                                mock_upload_parts, mock_initiate, manager):
+    @patch.object(MultipartUploadManager, "_initiate_upload")
+    @patch.object(MultipartUploadManager, "_upload_parts_concurrent")
+    @patch.object(MultipartUploadManager, "_complete_upload")
+    @patch.object(MultipartUploadManager, "_abort_upload")
+    @patch("together.filemanager.os.stat")
+    def test_upload_success_flow(
+        self,
+        mock_stat,
+        mock_abort,
+        mock_complete,
+        mock_upload_parts,
+        mock_initiate,
+        manager,
+    ):
         """Test successful complete upload flow"""
         # Setup mocks
         mock_stat.return_value.st_size = 200 * 1024 * 1024  # 200MB
-        
+
         mock_initiate.return_value = {
             "upload_id": "test-upload",
             "file_id": "test-file",
-            "parts": [{"part_number": 1}]
+            "parts": [{"part_number": 1}],
         }
-        
+
         mock_upload_parts.return_value = [{"part_number": 1, "etag": "etag1"}]
-        
+
         expected_response = FileResponse(
             id="test-file",
             object=ObjectType.File,
             filename="test.jsonl",
             bytes=200 * 1024 * 1024,
-            purpose=FilePurpose.FineTune
+            purpose=FilePurpose.FineTune,
         )
         mock_complete.return_value = expected_response
-        
+
         # Test
         result = manager.upload("test-url", Path("test.jsonl"), FilePurpose.FineTune)
-        
+
         # Assertions
         assert result == expected_response
         mock_initiate.assert_called_once()
@@ -337,28 +353,29 @@ class TestMultipartUploadManager:
         mock_complete.assert_called_once()
         mock_abort.assert_not_called()
 
-    @patch.object(MultipartUploadManager, '_initiate_upload')
-    @patch.object(MultipartUploadManager, '_upload_parts_concurrent')
-    @patch.object(MultipartUploadManager, '_abort_upload')
-    @patch('together.filemanager.os.stat')
-    def test_upload_failure_calls_abort(self, mock_stat, mock_abort, 
-                                       mock_upload_parts, mock_initiate, manager):
+    @patch.object(MultipartUploadManager, "_initiate_upload")
+    @patch.object(MultipartUploadManager, "_upload_parts_concurrent")
+    @patch.object(MultipartUploadManager, "_abort_upload")
+    @patch("together.filemanager.os.stat")
+    def test_upload_failure_calls_abort(
+        self, mock_stat, mock_abort, mock_upload_parts, mock_initiate, manager
+    ):
         """Test that abort is called when upload fails"""
         # Setup mocks
         mock_stat.return_value.st_size = 200 * 1024 * 1024  # 200MB
-        
+
         mock_initiate.return_value = {
             "upload_id": "test-upload",
             "file_id": "test-file",
-            "parts": [{"part_number": 1}]
+            "parts": [{"part_number": 1}],
         }
-        
+
         # Make upload parts fail
         mock_upload_parts.side_effect = Exception("Upload failed")
-        
+
         # Test
         with pytest.raises(Exception, match="Upload failed"):
             manager.upload("test-url", Path("test.jsonl"), FilePurpose.FineTune)
-        
+
         # Verify abort was called for cleanup
         mock_abort.assert_called_once_with("test-url", "test-upload", "test-file")

--- a/tests/unit/test_multipart_upload_manager.py
+++ b/tests/unit/test_multipart_upload_manager.py
@@ -1,0 +1,364 @@
+import pytest
+from unittest.mock import Mock, patch, MagicMock
+from pathlib import Path
+
+from together.filemanager import MultipartUploadManager
+from together.constants import (
+    MIN_PART_SIZE_MB,
+    TARGET_PART_SIZE_MB,
+    MAX_MULTIPART_PARTS,
+    MULTIPART_UPLOAD_TIMEOUT,
+    MAX_FILE_SIZE_GB,
+    NUM_BYTES_IN_GB,
+)
+from together.types import FilePurpose, FileResponse
+from together.types.common import ObjectType
+from together.together_response import TogetherResponse
+from together.error import FileTypeError
+
+
+class TestMultipartUploadManager:
+    """Test suite for MultipartUploadManager class"""
+
+    @pytest.fixture
+    def mock_client(self):
+        """Create a mock TogetherClient"""
+        return Mock()
+
+    @pytest.fixture
+    def manager(self, mock_client):
+        """Create a MultipartUploadManager instance with mock client"""
+        return MultipartUploadManager(mock_client)
+
+    def test_init(self, mock_client):
+        """Test MultipartUploadManager initialization"""
+        manager = MultipartUploadManager(mock_client)
+        assert manager._client == mock_client
+        assert manager.max_concurrent_parts == 4
+
+    def test_get_file_type_jsonl(self, manager):
+        """Test file type detection for .jsonl files"""
+        file = Path("test.jsonl")
+        assert manager._get_file_type(file) == "jsonl"
+
+    def test_get_file_type_parquet(self, manager):
+        """Test file type detection for .parquet files"""
+        file = Path("test.parquet")
+        assert manager._get_file_type(file) == "parquet"
+
+    def test_get_file_type_csv(self, manager):
+        """Test file type detection for .csv files"""
+        file = Path("test.csv")
+        assert manager._get_file_type(file) == "csv"
+
+    def test_get_file_type_unknown_defaults_to_jsonl(self, manager):
+        """Test that unknown file types default to jsonl"""
+        file = Path("test.txt")
+        assert manager._get_file_type(file) == "jsonl"
+
+    def test_calculate_parts_small_file(self, manager):
+        """Test part calculation for files smaller than target part size"""
+        file_size = 50 * 1024 * 1024  # 50MB
+        part_size, num_parts = manager._calculate_parts(file_size)
+        
+        assert num_parts == 1
+        assert part_size == file_size
+
+    def test_calculate_parts_medium_file(self, manager):
+        """Test part calculation for medium-sized files"""
+        file_size = 500 * 1024 * 1024  # 500MB
+        part_size, num_parts = manager._calculate_parts(file_size)
+        
+        expected_parts = 5  # 500MB / 100MB = 5 parts
+        expected_part_size = 100 * 1024 * 1024  # 100MB
+        
+        assert num_parts == expected_parts
+        assert part_size == expected_part_size
+
+    def test_calculate_parts_large_file(self, manager):
+        """Test part calculation for large files that require scaling"""
+        file_size = 50 * 1024 * 1024 * 1024  # 50GB
+        part_size, num_parts = manager._calculate_parts(file_size)
+        
+        # Should use maximum parts and scale part size
+        assert num_parts == MAX_MULTIPART_PARTS  # 250
+        expected_part_size = file_size // MAX_MULTIPART_PARTS
+        assert part_size >= expected_part_size
+
+    def test_calculate_parts_respects_minimum_part_size(self, manager):
+        """Test that minimum part size is respected"""
+        # Create a scenario where calculated part size would be too small
+        file_size = 1000 * 1024 * 1024  # 1GB
+        
+        with patch.object(manager, '_calculate_parts', wraps=manager._calculate_parts) as mock_calc:
+            part_size, num_parts = manager._calculate_parts(file_size)
+            
+            # Ensure no part is smaller than minimum
+            min_part_size = MIN_PART_SIZE_MB * 1024 * 1024
+            assert part_size >= min_part_size
+
+    @patch('together.filemanager.api_requestor.APIRequestor')
+    def test_initiate_upload_success(self, mock_requestor_class, manager):
+        """Test successful upload initiation"""
+        # Setup mock
+        mock_requestor = Mock()
+        mock_requestor_class.return_value = mock_requestor
+        
+        mock_response = TogetherResponse(
+            data={
+                "upload_id": "test-upload-id",
+                "file_id": "test-file-id",
+                "parts": [
+                    {
+                        "part_number": 1,
+                        "url": "https://presigned-url-1.com",
+                        "headers": {"Authorization": "Bearer token"}
+                    }
+                ]
+            },
+            headers={}
+        )
+        mock_requestor.request.return_value = (mock_response, None, None)
+        
+        # Test
+        result = manager._initiate_upload(
+            "test-url", 
+            Path("test.jsonl"), 
+            1024 * 1024,  # 1MB
+            1, 
+            FilePurpose.FineTune,
+            "jsonl"
+        )
+        
+        # Assertions
+        assert result["upload_id"] == "test-upload-id"
+        assert result["file_id"] == "test-file-id"
+        assert len(result["parts"]) == 1
+        
+        # Verify API call
+        mock_requestor.request.assert_called_once()
+        call_args = mock_requestor.request.call_args[1]["options"]
+        assert call_args.method == "POST"
+        assert call_args.url == "files/multipart/initiate"
+
+    @patch('together.filemanager.requests.put')
+    def test_upload_single_part_success(self, mock_put, manager):
+        """Test successful single part upload"""
+        # Setup mock response
+        mock_response = Mock()
+        mock_response.headers = {"ETag": '"test-etag"'}
+        mock_response.raise_for_status = Mock()
+        mock_put.return_value = mock_response
+        
+        # Test data
+        part_info = {
+            "part_number": 1,
+            "url": "https://presigned-url.com",
+            "headers": {"Authorization": "Bearer token"}
+        }
+        part_data = b"test data"
+        
+        # Test
+        etag = manager._upload_single_part(part_info, part_data)
+        
+        # Assertions
+        assert etag == "test-etag"
+        mock_put.assert_called_once_with(
+            "https://presigned-url.com",
+            data=part_data,
+            headers={"Authorization": "Bearer token"},
+            timeout=MULTIPART_UPLOAD_TIMEOUT
+        )
+        mock_response.raise_for_status.assert_called_once()
+
+    @patch('together.filemanager.requests.put')
+    def test_upload_single_part_no_etag_error(self, mock_put, manager):
+        """Test error when no ETag is returned"""
+        # Setup mock response without ETag
+        mock_response = Mock()
+        mock_response.headers = {}
+        mock_response.raise_for_status = Mock()
+        mock_put.return_value = mock_response
+        
+        part_info = {"part_number": 1, "url": "https://test.com", "headers": {}}
+        part_data = b"test data"
+        
+        # Test
+        with pytest.raises(Exception, match="No ETag returned for part 1"):
+            manager._upload_single_part(part_info, part_data)
+
+    @patch('together.filemanager.api_requestor.APIRequestor')
+    def test_complete_upload_success(self, mock_requestor_class, manager):
+        """Test successful upload completion"""
+        # Setup mock
+        mock_requestor = Mock()
+        mock_requestor_class.return_value = mock_requestor
+        
+        mock_response = TogetherResponse(
+            data={
+                "file": {
+                    "id": "test-file-id",
+                    "object": "file",
+                    "filename": "test.jsonl",
+                    "bytes": 1024,
+                    "purpose": "fine-tune"
+                }
+            },
+            headers={}
+        )
+        mock_requestor.request.return_value = (mock_response, None, None)
+        
+        # Test
+        completed_parts = [{"part_number": 1, "etag": "test-etag"}]
+        result = manager._complete_upload("test-url", "upload-id", "file-id", completed_parts)
+        
+        # Assertions
+        assert isinstance(result, FileResponse)
+        assert result.id == "test-file-id"
+        assert result.filename == "test.jsonl"
+        
+        # Verify API call
+        mock_requestor.request.assert_called_once()
+        call_args = mock_requestor.request.call_args[1]["options"]
+        assert call_args.method == "POST"
+        assert call_args.url == "files/multipart/complete"
+
+    @patch('together.filemanager.api_requestor.APIRequestor')
+    def test_abort_upload_success(self, mock_requestor_class, manager):
+        """Test successful upload abort"""
+        # Setup mock
+        mock_requestor = Mock()
+        mock_requestor_class.return_value = mock_requestor
+        mock_requestor.request.return_value = (Mock(), None, None)
+        
+        # Test
+        manager._abort_upload("test-url", "upload-id", "file-id")
+        
+        # Verify API call
+        mock_requestor.request.assert_called_once()
+        call_args = mock_requestor.request.call_args[1]["options"]
+        assert call_args.method == "POST"
+        assert call_args.url == "files/multipart/abort"
+        assert call_args.params["upload_id"] == "upload-id"
+        assert call_args.params["file_id"] == "file-id"
+
+    @patch('together.filemanager.ThreadPoolExecutor')
+    @patch('together.filemanager.open', create=True)
+    def test_upload_parts_concurrent(self, mock_open, mock_executor_class, manager):
+        """Test concurrent part upload functionality"""
+        # Setup mocks
+        mock_file = Mock()
+        mock_file.seek = Mock()
+        mock_file.read.return_value = b"test data"
+        mock_open.return_value.__enter__.return_value = mock_file
+        
+        mock_executor = Mock()
+        mock_executor_class.return_value.__enter__.return_value = mock_executor
+        
+        # Mock futures
+        mock_future1 = Mock()
+        mock_future1.result.return_value = "etag1"
+        mock_future2 = Mock()
+        mock_future2.result.return_value = "etag2"
+        
+        mock_executor.submit.side_effect = [mock_future1, mock_future2]
+        
+        # Mock as_completed
+        with patch('together.filemanager.as_completed', return_value=[mock_future1, mock_future2]):
+            upload_info = {
+                "parts": [
+                    {"part_number": 1, "url": "url1", "headers": {}},
+                    {"part_number": 2, "url": "url2", "headers": {}}
+                ]
+            }
+            
+            # Test
+            result = manager._upload_parts_concurrent(Path("test.jsonl"), upload_info, 1024)
+            
+            # Assertions
+            assert len(result) == 2
+            assert result[0]["part_number"] == 1
+            assert result[0]["etag"] == "etag1"
+            assert result[1]["part_number"] == 2
+            assert result[1]["etag"] == "etag2"
+            
+            # Verify executor was used
+            assert mock_executor.submit.call_count == 2
+
+    @patch('together.filemanager.os.stat')
+    def test_file_size_exceeds_limit_raises_error(self, mock_stat, manager):
+        """Test that files exceeding size limit raise FileTypeError with clear message"""
+        # Setup - file size over limit
+        file_size = int((MAX_FILE_SIZE_GB + 1) * NUM_BYTES_IN_GB)  # 26GB
+        mock_stat.return_value.st_size = file_size
+        
+        # Should raise FileTypeError with descriptive message
+        with pytest.raises(FileTypeError) as exc_info:
+            manager.upload("test-url", Path("test.jsonl"), FilePurpose.FineTune)
+        
+        error_message = str(exc_info.value)
+        assert "26.0GB exceeds maximum supported size of 25.0GB" in error_message
+
+    @patch.object(MultipartUploadManager, '_initiate_upload')
+    @patch.object(MultipartUploadManager, '_upload_parts_concurrent')
+    @patch.object(MultipartUploadManager, '_complete_upload')
+    @patch.object(MultipartUploadManager, '_abort_upload')
+    @patch('together.filemanager.os.stat')
+    def test_upload_success_flow(self, mock_stat, mock_abort, mock_complete, 
+                                mock_upload_parts, mock_initiate, manager):
+        """Test successful complete upload flow"""
+        # Setup mocks
+        mock_stat.return_value.st_size = 200 * 1024 * 1024  # 200MB
+        
+        mock_initiate.return_value = {
+            "upload_id": "test-upload",
+            "file_id": "test-file",
+            "parts": [{"part_number": 1}]
+        }
+        
+        mock_upload_parts.return_value = [{"part_number": 1, "etag": "etag1"}]
+        
+        expected_response = FileResponse(
+            id="test-file",
+            object=ObjectType.File,
+            filename="test.jsonl",
+            bytes=200 * 1024 * 1024,
+            purpose=FilePurpose.FineTune
+        )
+        mock_complete.return_value = expected_response
+        
+        # Test
+        result = manager.upload("test-url", Path("test.jsonl"), FilePurpose.FineTune)
+        
+        # Assertions
+        assert result == expected_response
+        mock_initiate.assert_called_once()
+        mock_upload_parts.assert_called_once()
+        mock_complete.assert_called_once()
+        mock_abort.assert_not_called()
+
+    @patch.object(MultipartUploadManager, '_initiate_upload')
+    @patch.object(MultipartUploadManager, '_upload_parts_concurrent')
+    @patch.object(MultipartUploadManager, '_abort_upload')
+    @patch('together.filemanager.os.stat')
+    def test_upload_failure_calls_abort(self, mock_stat, mock_abort, 
+                                       mock_upload_parts, mock_initiate, manager):
+        """Test that abort is called when upload fails"""
+        # Setup mocks
+        mock_stat.return_value.st_size = 200 * 1024 * 1024  # 200MB
+        
+        mock_initiate.return_value = {
+            "upload_id": "test-upload",
+            "file_id": "test-file",
+            "parts": [{"part_number": 1}]
+        }
+        
+        # Make upload parts fail
+        mock_upload_parts.side_effect = Exception("Upload failed")
+        
+        # Test
+        with pytest.raises(Exception, match="Upload failed"):
+            manager.upload("test-url", Path("test.jsonl"), FilePurpose.FineTune)
+        
+        # Verify abort was called for cleanup
+        mock_abort.assert_called_once_with("test-url", "test-upload", "test-file")

--- a/tests/unit/test_multipart_upload_manager.py
+++ b/tests/unit/test_multipart_upload_manager.py
@@ -159,9 +159,9 @@ class TestMultipartUploadManager:
 
         # Test data
         part_info = {
-            "part_number": 1,
-            "url": "https://presigned-url.com",
-            "headers": {"Authorization": "Bearer token"},
+            "PartNumber": 1,
+            "URL": "https://presigned-url.com",
+            "Headers": {"Authorization": "Bearer token"},
         }
         part_data = b"test data"
 
@@ -187,7 +187,7 @@ class TestMultipartUploadManager:
         mock_response.raise_for_status = Mock()
         mock_put.return_value = mock_response
 
-        part_info = {"part_number": 1, "url": "https://test.com", "headers": {}}
+        part_info = {"PartNumber": 1, "URL": "https://test.com", "Headers": {}}
         part_data = b"test data"
 
         # Test
@@ -279,8 +279,8 @@ class TestMultipartUploadManager:
         ):
             upload_info = {
                 "parts": [
-                    {"part_number": 1, "url": "url1", "headers": {}},
-                    {"part_number": 2, "url": "url2", "headers": {}},
+                    {"PartNumber": 1, "URL": "url1", "Headers": {}},
+                    {"PartNumber": 2, "URL": "url2", "Headers": {}},
                 ]
             }
 


### PR DESCRIPTION
*Have you read the [Contributing Guidelines](https://github.com/togethercomputer/together/blob/main/CONTRIBUTING.md)?*


## Describe your changes

Add Multipart Upload Support for Large Files
### Summary
- Implements multipart file upload capability to support fine-tuning with datasets exceeding 5GB, addressing the current single-upload size limitation.
Changes
### Core Implementation
- MultipartUploadManager: New class implementing 3-phase multipart upload (initiate → upload parts → complete)
- Size-based routing: routing between single upload (≤5GB) and multipart upload (>5GB)
- Concurrent part uploads: simultaneous part uploads with progress tracking via tqdm
- File size validation: 25GB maximum (for now)
-Configuration centralized in constants.py
