### PR TITLE
Fix Discord badge link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 # Together Python API library
 
 [![PyPI version](https://img.shields.io/pypi/v/together.svg)](https://pypi.org/project/together/)
-[![Discord](https://dcbadge.vercel.app/api/server/9Rk6sSeWEG?style=flat&compact=true)](https://discord.com/invite/9Rk6sSeWEG)
+[![Discord](https://dcbadge.limes.pink/api/server/https://discord.gg/9Rk6sSeWEG?style=flat&theme=discord-inverted)](https://discord.com/invite/9Rk6sSeWEG)
 [![Twitter](https://img.shields.io/twitter/url/https/twitter.com/togethercompute.svg?style=social&label=Follow%20%40togethercompute)](https://twitter.com/togethercompute)
 
 The [Together Python API Library](https://pypi.org/project/together/) is the official Python client for Together's API platform, providing a convenient way for interacting with the REST APIs and enables easy integrations with Python 3.10+ applications with easy to use synchronous and asynchronous clients.


### PR DESCRIPTION
Fixes issue brought up in https://github.com/togethercomputer/together-python/pull/352 with a https://github.com/gitlimes/dcbadge badge

Before:
<img width="439" height="111" alt="image" src="https://github.com/user-attachments/assets/b206b114-0239-4a35-a4a5-7897cd97820e" />

After:
<img width="533" height="119" alt="image" src="https://github.com/user-attachments/assets/87b778cb-1697-4bb5-ad24-d1584e528cf3" />
