### PR TITLE
Remove black from dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,6 @@ numpy = [
     { version = ">=1.26.0", python = ">=3.12" },
 ]
 pillow = "^11.1.0"
-black = "^25.9.0"
 
 [tool.poetry.extras]
 pyarrow = ["pyarrow"]


### PR DESCRIPTION
black is a development dependency and should not be included as a package dependency. This can cause dependency conflicts with projects that use different versions of black. Note that black is already correctly included in a dependency group `tool.poetry.group.quality.dependencies` so its inclusion here is unnecessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes `black` from runtime dependencies to avoid shipping it to end users; formatting remains managed under the `quality` dev group.
> 
> - Deletes `black` from `tool.poetry.dependencies`
> - Retains `black` under `tool.poetry.group.quality.dependencies`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0689004a1da07e35ba2bb183210127968824aa57. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->