### PR TITLE
fix: prevent TogetherException.__repr__ crash on non-serializable headers

### DIFF
--- a/src/together/error.py
+++ b/src/together/error.py
@@ -44,7 +44,8 @@ class TogetherException(Exception):
                 "status": self.http_status,
                 "request_id": self.request_id,
                 "headers": self.headers,
-            }
+            },
+            default=str,
         )
         return "%s(%r)" % (self.__class__.__name__, repr_message)
 

--- a/tests/unit/test_error.py
+++ b/tests/unit/test_error.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+import json
+from typing import Any
+from unittest.mock import MagicMock
+
+from together.error import TogetherException
+
+
+class TestTogetherExceptionRepr:
+    def test_repr_with_dict_headers(self):
+        """Test __repr__ works with standard dict headers."""
+        exc = TogetherException(
+            message="test error",
+            headers={"Content-Type": "application/json"},
+            http_status=400,
+            request_id="req-123",
+        )
+        result = repr(exc)
+        assert "TogetherException" in result
+        assert "test error" in result
+
+    def test_repr_with_non_serializable_headers(self):
+        """
+        Test __repr__ does not crash when headers contain
+        non-JSON-serializable objects (e.g. CIMultiDictProxy).
+
+        Regression test for https://github.com/togethercomputer/together-python/issues/108
+        """
+
+        class NonSerializable:
+            """A class that is not JSON serializable."""
+
+            def __str__(self) -> str:
+                return "NonSerializable()"
+
+        exc = TogetherException(
+            message="test error",
+            headers=NonSerializable(),
+            http_status=500,
+            request_id="req-456",
+        )
+        # Should not raise TypeError
+        result = repr(exc)
+        assert "TogetherException" in result
+        assert "NonSerializable()" in result
+
+    def test_repr_with_mock_cimultidictproxy(self):
+        """
+        Test __repr__ handles an object mimicking aiohttp's
+        CIMultiDictProxy, which triggered the original bug.
+        """
+        mock_headers = MagicMock()
+        mock_headers.__str__ = lambda self: "{'key': 'value'}"
+
+        exc = TogetherException(
+            message="connection error",
+            headers=mock_headers,
+            http_status=502,
+        )
+        # Should not raise TypeError
+        result = repr(exc)
+        assert "TogetherException" in result
+
+    def test_repr_with_none_headers(self):
+        """Test __repr__ works when headers is None (default)."""
+        exc = TogetherException(message="test error")
+        result = repr(exc)
+        assert "TogetherException" in result
+
+    def test_repr_output_is_valid_json_inside(self):
+        """Test that the JSON portion inside __repr__ is valid."""
+        exc = TogetherException(
+            message="test error",
+            headers={"X-Request-Id": "abc"},
+            http_status=429,
+            request_id="req-789",
+        )
+        result = repr(exc)
+        # Extract the JSON string from repr output: ClassName('json_string')
+        # The format is: TogetherException('{"response": ...}')
+        json_start = result.index("'") + 1
+        json_end = result.rindex("'")
+        json_str = result[json_start:json_end]
+        parsed = json.loads(json_str)
+        assert parsed["status"] == 429
+        assert parsed["request_id"] == "req-789"


### PR DESCRIPTION
## Summary
- Added `default=str` to `json.dumps()` in `TogetherException.__repr__` so that non-JSON-serializable objects (e.g. aiohttp's `CIMultiDictProxy`) are gracefully converted to strings instead of raising `TypeError`
- Added unit tests covering `__repr__` with dict headers, non-serializable headers, mock CIMultiDictProxy, and None headers

## Problem
When a `TogetherException` is constructed with headers that contain non-JSON-serializable objects (such as `CIMultiDictProxy` from aiohttp), calling `repr()` or `print()` on the exception raises a `TypeError`:

```
TypeError: Object of type CIMultiDictProxy is not JSON serializable
```

This is a one-line fix: adding `default=str` to the `json.dumps()` call in `__repr__`.

## Test plan
- [x] Added `tests/unit/test_error.py` with 5 test cases
- [x] All existing unit tests continue to pass
- [x] Verified `repr()` no longer crashes with non-serializable header objects

Fixes #108

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to exception stringification plus new unit tests; behavior only affects debug/representation and should be safe aside from slightly different header rendering.
> 
> **Overview**
> Prevents `TogetherException.__repr__` from raising `TypeError` when `headers` contains non-JSON-serializable objects by adding `default=str` to the `json.dumps()` call.
> 
> Adds a new unit test suite (`tests/unit/test_error.py`) covering `__repr__` behavior with dict headers, `None`, and non-serializable/mocked `CIMultiDictProxy`-like header objects, including validation that the embedded JSON is parseable.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 365df9b3d45a8ed88ad6d125b4020f7bc7eb937b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->