### PR TITLE
fix: prevent TogetherException repr crash on non-JSON-serializable headers

### DIFF
--- a/src/together/error.py
+++ b/src/together/error.py
@@ -44,7 +44,8 @@ class TogetherException(Exception):
                 "status": self.http_status,
                 "request_id": self.request_id,
                 "headers": self.headers,
-            }
+            },
+            default=str,
         )
         return "%s(%r)" % (self.__class__.__name__, repr_message)
 

--- a/src/together/error.py
+++ b/src/together/error.py
@@ -1,11 +1,22 @@
 from __future__ import annotations
 
 import json
+from collections.abc import Mapping
 from typing import Any, Dict
 
 from requests import RequestException
 
 from together.types.error import TogetherErrorResponse
+
+
+def _json_safe_headers(headers: str | Dict[Any, Any] | None) -> str | Dict[Any, Any]:
+    if headers is None:
+        return {}
+    if isinstance(headers, str):
+        return headers
+    if isinstance(headers, Mapping):
+        return {str(key): value for key, value in headers.items()}
+    return str(headers)
 
 
 class TogetherException(Exception):
@@ -43,7 +54,7 @@ class TogetherException(Exception):
                 "response": self._message,
                 "status": self.http_status,
                 "request_id": self.request_id,
-                "headers": self.headers,
+                "headers": _json_safe_headers(self.headers),
             },
             default=str,
         )

--- a/tests/unit/test_error_repr.py
+++ b/tests/unit/test_error_repr.py
@@ -1,0 +1,122 @@
+"""Tests for TogetherException.__repr__ with non-JSON-serializable headers."""
+
+from __future__ import annotations
+
+import json
+from collections import OrderedDict
+from typing import Any, Iterator
+from unittest.mock import MagicMock
+
+import pytest
+
+from together.error import (
+    TogetherException,
+    AuthenticationError,
+    ResponseError,
+    APIError,
+)
+
+
+class FakeMultiDictProxy:
+    """Simulates aiohttp's CIMultiDictProxy — not JSON serializable."""
+
+    def __init__(self, data: dict[str, str]) -> None:
+        self._data = data
+
+    def __iter__(self) -> Iterator[str]:
+        return iter(self._data)
+
+    def __len__(self) -> int:
+        return len(self._data)
+
+    def __getitem__(self, key: str) -> str:
+        return self._data[key]
+
+    def __repr__(self) -> str:
+        return f"<FakeMultiDictProxy({self._data!r})>"
+
+
+class TestExceptionReprNonSerializable:
+    """Verify __repr__ doesn't crash on non-JSON-serializable headers (issue #108)."""
+
+    def test_repr_with_dict_headers(self) -> None:
+        """Normal dict headers should still work fine."""
+        exc = TogetherException(
+            message="test error",
+            headers={"Content-Type": "application/json"},
+            http_status=400,
+            request_id="req-123",
+        )
+        result = repr(exc)
+        assert "TogetherException" in result
+        assert "test error" in result
+
+    def test_repr_with_multidict_proxy_headers(self) -> None:
+        """CIMultiDictProxy-like headers must not crash repr (issue #108)."""
+        fake_headers = FakeMultiDictProxy(
+            {"Content-Type": "application/json", "X-Request-Id": "abc"}
+        )
+        exc = TogetherException(
+            message="server error",
+            headers=fake_headers,  # type: ignore[arg-type]
+            http_status=500,
+            request_id="req-456",
+        )
+        # Before fix: TypeError: Object of type FakeMultiDictProxy
+        #             is not JSON serializable
+        result = repr(exc)
+        assert "TogetherException" in result
+        assert "server error" in result
+
+    def test_repr_with_none_headers(self) -> None:
+        """None headers (default) should work."""
+        exc = TogetherException(message="no headers")
+        result = repr(exc)
+        assert "TogetherException" in result
+
+    def test_repr_with_string_headers(self) -> None:
+        """String headers should work."""
+        exc = TogetherException(
+            message="string headers", headers="raw-header-string"
+        )
+        result = repr(exc)
+        assert "TogetherException" in result
+
+    def test_repr_with_nested_non_serializable(self) -> None:
+        """Dict headers containing non-serializable values should not crash."""
+        exc = TogetherException(
+            message="nested issue",
+            headers={"key": MagicMock()},  # type: ignore[dict-item]
+            http_status=502,
+        )
+        result = repr(exc)
+        assert "TogetherException" in result
+
+    def test_repr_output_is_valid_after_fix(self) -> None:
+        """repr should produce parseable output (class name + JSON string)."""
+        exc = TogetherException(
+            message="validation error",
+            headers={"Authorization": "Bearer ***"},
+            http_status=422,
+            request_id="req-789",
+        )
+        result = repr(exc)
+        assert result.startswith("TogetherException(")
+        # The inner string should be valid JSON
+        inner = result[len("TogetherException(") + 1 : -2]  # strip quotes
+        parsed = json.loads(inner)
+        assert parsed["status"] == 422
+        assert parsed["request_id"] == "req-789"
+
+    def test_subclass_repr_with_non_serializable_headers(self) -> None:
+        """Subclasses should also benefit from the fix."""
+        fake_headers = FakeMultiDictProxy({"X-Rate-Limit": "100"})
+
+        for ExcClass in (AuthenticationError, ResponseError, APIError):
+            exc = ExcClass(
+                message="subclass test",
+                headers=fake_headers,  # type: ignore[arg-type]
+                http_status=429,
+            )
+            result = repr(exc)
+            assert ExcClass.__name__ in result

--- a/tests/unit/test_error_repr.py
+++ b/tests/unit/test_error_repr.py
@@ -3,37 +3,16 @@
 from __future__ import annotations
 
 import json
-from collections import OrderedDict
-from typing import Any, Iterator
 from unittest.mock import MagicMock
 
-import pytest
+from multidict import CIMultiDict, CIMultiDictProxy
 
 from together.error import (
-    TogetherException,
+    APIError,
     AuthenticationError,
     ResponseError,
-    APIError,
+    TogetherException,
 )
-
-
-class FakeMultiDictProxy:
-    """Simulates aiohttp's CIMultiDictProxy — not JSON serializable."""
-
-    def __init__(self, data: dict[str, str]) -> None:
-        self._data = data
-
-    def __iter__(self) -> Iterator[str]:
-        return iter(self._data)
-
-    def __len__(self) -> int:
-        return len(self._data)
-
-    def __getitem__(self, key: str) -> str:
-        return self._data[key]
-
-    def __repr__(self) -> str:
-        return f"<FakeMultiDictProxy({self._data!r})>"
 
 
 class TestExceptionReprNonSerializable:
@@ -52,21 +31,28 @@ class TestExceptionReprNonSerializable:
         assert "test error" in result
 
     def test_repr_with_multidict_proxy_headers(self) -> None:
-        """CIMultiDictProxy-like headers must not crash repr (issue #108)."""
-        fake_headers = FakeMultiDictProxy(
-            {"Content-Type": "application/json", "X-Request-Id": "abc"}
+        """Real CIMultiDictProxy headers must not crash repr (issue #108)."""
+        headers = CIMultiDictProxy(
+            CIMultiDict(
+                {"Content-Type": "application/json", "X-Request-Id": "abc"}
+            )
         )
         exc = TogetherException(
             message="server error",
-            headers=fake_headers,  # type: ignore[arg-type]
+            headers=headers,  # type: ignore[arg-type]
             http_status=500,
             request_id="req-456",
         )
-        # Before fix: TypeError: Object of type FakeMultiDictProxy
+        # Before fix: TypeError: Object of type CIMultiDictProxy
         #             is not JSON serializable
         result = repr(exc)
         assert "TogetherException" in result
         assert "server error" in result
+        parsed = json.loads(result[len("TogetherException(") + 1 : -2])
+        assert parsed["headers"] == {
+            "Content-Type": "application/json",
+            "X-Request-Id": "abc",
+        }
 
     def test_repr_with_none_headers(self) -> None:
         """None headers (default) should work."""
@@ -110,12 +96,12 @@ class TestExceptionReprNonSerializable:
 
     def test_subclass_repr_with_non_serializable_headers(self) -> None:
         """Subclasses should also benefit from the fix."""
-        fake_headers = FakeMultiDictProxy({"X-Rate-Limit": "100"})
+        headers = CIMultiDictProxy(CIMultiDict({"X-Rate-Limit": "100"}))
 
         for ExcClass in (AuthenticationError, ResponseError, APIError):
             exc = ExcClass(
                 message="subclass test",
-                headers=fake_headers,  # type: ignore[arg-type]
+                headers=headers,  # type: ignore[arg-type]
                 http_status=429,
             )
             result = repr(exc)


### PR DESCRIPTION
## Problem

`TogetherException.__repr__` uses `json.dumps()` to serialize the exception's attributes (including `headers`) into a JSON string. When `headers` contains a non-JSON-serializable object like aiohttp's `CIMultiDictProxy`, this raises a `TypeError`:

```
TypeError: Object of type CIMultiDictProxy is not JSON serializable
```

This makes it impossible to `print()`, `repr()`, or log the exception — the debugging tool itself crashes.

## Root Cause

`json.dumps()` in `__repr__` has no fallback for non-serializable types:

```python
def __repr__(self) -> str:
    repr_message = json.dumps(
        {
            "response": self._message,
            "status": self.http_status,
            "request_id": self.request_id,
            "headers": self.headers,  # ← CIMultiDictProxy crashes here
        }
    )
```

## Fix

Add `default=str` to `json.dumps()` so non-serializable objects fall back to their string representation:

```python
repr_message = json.dumps(
    {...},
    default=str,  # ← fallback for non-serializable objects
)
```

This is the standard Python pattern for graceful JSON serialization of arbitrary objects.

## Tests

Added 7 unit tests covering:
- Normal dict headers (regression)
- `CIMultiDictProxy`-like headers (the reported bug)
- `None` headers (default case)
- String headers
- Nested non-serializable values
- Valid output format verification
- All exception subclasses inherit the fix

## Verified Locally

```
OLD CODE CRASHES: Object of type FakeMultiDictProxy is not JSON serializable
NEW CODE: OK -> {"headers": "<FakeMultiDictProxy({'Content-Type': 'application/json'})>"}
```

All 7 new tests pass. All 181 existing unit tests continue to pass.

Fixes #108

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: change is confined to exception stringification and adds tests; behavior only affects how errors are represented/logged when headers are non-JSON-serializable.
> 
> **Overview**
> Fixes `TogetherException.__repr__` to **never crash while logging/printing errors** when `headers` contains non-JSON-serializable types (e.g., `CIMultiDictProxy`).
> 
> Adds `_json_safe_headers` plus `json.dumps(..., default=str)` to safely stringify/normalize headers, and introduces a focused unit test suite covering dict/None/string headers, `CIMultiDictProxy`, nested non-serializable values, and subclass behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit df6e869b73db3f5798b60d2c86b81366932b9d84. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->