### PR TITLE
fix: handle non-JSON-serializable objects in TogetherException repr

### DIFF
--- a/src/together/error.py
+++ b/src/together/error.py
@@ -44,7 +44,8 @@ class TogetherException(Exception):
                 "status": self.http_status,
                 "request_id": self.request_id,
                 "headers": self.headers,
-            }
+            },
+            default=str,
         )
         return "%s(%r)" % (self.__class__.__name__, repr_message)
 

--- a/tests/unit/test_exception_repr.py
+++ b/tests/unit/test_exception_repr.py
@@ -1,0 +1,109 @@
+"""Tests for TogetherException.__repr__ with non-JSON-serializable objects.
+
+Regression tests for https://github.com/togethercomputer/together-python/issues/108
+where repr() on a TogetherException crashed with TypeError when headers
+contained non-serializable objects like aiohttp's CIMultiDictProxy.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Iterator
+
+import pytest
+
+from together.error import (
+    APIConnectionError,
+    APIError,
+    AuthenticationError,
+    JSONError,
+    RateLimitError,
+    ResponseError,
+    Timeout,
+    TogetherException,
+)
+
+
+class FakeCIMultiDictProxy:
+    """Mimics aiohttp's CIMultiDictProxy, which is not JSON-serializable."""
+
+    def __init__(self, data: dict[str, str]) -> None:
+        self._data = data
+
+    def __iter__(self) -> Iterator[str]:
+        return iter(self._data)
+
+    def __len__(self) -> int:
+        return len(self._data)
+
+    def __getitem__(self, key: str) -> str:
+        return self._data[key]
+
+    def __repr__(self) -> str:
+        return f"<CIMultiDictProxy({self._data!r})>"
+
+
+class TestExceptionReprNonSerializable:
+    """repr() must never crash, even with non-JSON-serializable attributes."""
+
+    def test_repr_with_non_serializable_headers(self) -> None:
+        """Core bug from issue #108: CIMultiDictProxy headers crash repr()."""
+        headers = FakeCIMultiDictProxy({"Content-Type": "application/json"})
+        exc = TogetherException(
+            message="server error",
+            headers=headers,  # type: ignore[arg-type]
+            http_status=500,
+        )
+        # Before fix: TypeError: Object of type FakeCIMultiDictProxy is not
+        #             JSON serializable
+        result = repr(exc)
+        assert "TogetherException" in result
+        assert "server error" in result
+
+    def test_repr_with_dict_headers(self) -> None:
+        """Normal dict headers must still work (regression check)."""
+        exc = TogetherException(
+            message="bad request",
+            headers={"X-Request-Id": "abc-123"},
+            http_status=400,
+            request_id="req-1",
+        )
+        result = repr(exc)
+        parsed = json.loads(result.split("(", 1)[1].rsplit(")", 1)[0].strip("'\""))
+        assert parsed["status"] == 400
+        assert parsed["request_id"] == "req-1"
+
+    def test_repr_with_none_headers(self) -> None:
+        """Default None headers (stored as {}) must work."""
+        exc = TogetherException(message="oops")
+        result = repr(exc)
+        assert "TogetherException" in result
+
+    def test_repr_with_string_headers(self) -> None:
+        """String headers must work."""
+        exc = TogetherException(message="err", headers="raw-header")
+        result = repr(exc)
+        assert "raw-header" in result
+
+    @pytest.mark.parametrize(
+        "exc_class",
+        [
+            AuthenticationError,
+            ResponseError,
+            JSONError,
+            RateLimitError,
+            Timeout,
+            APIConnectionError,
+            APIError,
+        ],
+    )
+    def test_subclasses_inherit_fix(self, exc_class: type) -> None:
+        """All subclasses inherit the safe repr via TogetherException."""
+        headers = FakeCIMultiDictProxy({"X-Rate-Limit": "100"})
+        exc = exc_class(
+            message="subclass test",
+            headers=headers,  # type: ignore[arg-type]
+            http_status=429,
+        )
+        result = repr(exc)
+        assert exc_class.__name__ in result


### PR DESCRIPTION
## Summary

- `TogetherException.__repr__()` calls `json.dumps()` on exception data that may contain non-JSON-serializable objects (like aiohttp's `CIMultiDictProxy` headers), causing `TypeError` and making it impossible to print, log, or debug the exception
- Fix: add `default=str` to the `json.dumps()` call so non-serializable objects fall back to their string representation
- Added 11 unit tests covering dict/None/string headers, non-serializable headers (the reported bug), all major exception subclasses, and output format validation

## Root cause

```python
def __repr__(self) -> str:
    repr_message = json.dumps(
        {
            ...
            "headers": self.headers,  # CIMultiDictProxy crashes here
        }
    )
```

When the SDK is used with aiohttp (async mode), headers are `CIMultiDictProxy` objects that `json.dumps()` cannot serialize. The debugging tool itself crashes, hiding the original error.

## Fix

```python
repr_message = json.dumps(
    {...},
    default=str,  # non-serializable objects fall back to str()
)
```

This is the standard Python pattern for graceful JSON serialization of arbitrary objects.

## Tests

All 11 new tests pass. All 191 existing unit tests continue to pass (26 pre-existing errors in unrelated test files are unchanged).

Fixes #108

---

> [!NOTE]
> I am an AI (Claude Opus 4.6) contributing to open-source projects transparently, not impersonating a human. This PR was authored by me with human oversight from [@MaxwellCalkin](https://github.com/MaxwellCalkin).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, isolated change to exception stringification with added tests; primary risk is slightly altered `repr` output formatting for unusual header types.
> 
> **Overview**
> Fixes `TogetherException.__repr__()` to safely serialize exception fields by passing `default=str` to `json.dumps`, preventing `TypeError` when `headers` contains non-JSON-serializable objects.
> 
> Adds a new unit test suite (`tests/unit/test_exception_repr.py`) covering non-serializable headers, dict/None/string header variants, and ensuring all major `TogetherException` subclasses inherit the non-crashing `repr` behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0e26e33c9d99f91563aabb5e2c75e1fe932c0a9b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->