### PR TITLE
fix(types): add top_logprobs to LogprobsPart to match API response shape

### DIFF
--- a/src/together/types/common.py
+++ b/src/together/types/common.py
@@ -42,6 +42,8 @@ class LogprobsPart(BaseModel):
     tokens: List[str | None] | None = None
     # token logprob list
     token_logprobs: List[float | None] | None = None
+    # top-k logprobs per token: one dict per token, mapping token string to log-probability
+    top_logprobs: List[Dict[str, float]] | None = None
 
 
 class PromptPart(BaseModel):

--- a/tests/unit/test_logprobs_type.py
+++ b/tests/unit/test_logprobs_type.py
@@ -1,0 +1,39 @@
+import warnings
+
+from together.types.common import LogprobsPart
+
+
+def test_logprobs_part_top_logprobs_is_list():
+    """LogprobsPart.top_logprobs must accept a list of per-token dicts (issue #443)."""
+    lp = LogprobsPart(
+        tokens=["Hello", "."],
+        token_logprobs=[-2.6e-06, -4.8e-05],
+        top_logprobs=[
+            {"Hello": -2.6e-06, "hello": -13.5, " Hello": -13.875},
+            {".": -4.8e-05, "!": -10.2},
+        ],
+    )
+    assert isinstance(lp.top_logprobs, list)
+    assert len(lp.top_logprobs) == 2
+    assert isinstance(lp.top_logprobs[0], dict)
+    assert lp.top_logprobs[0]["Hello"] == -2.6e-06
+
+
+def test_logprobs_part_model_dump_no_warning():
+    """model_dump() must not emit PydanticSerializationUnexpectedValue for top_logprobs."""
+    lp = LogprobsPart(
+        tokens=["Hello"],
+        token_logprobs=[-2.6e-06],
+        top_logprobs=[{"Hello": -2.6e-06, "hello": -13.5}],
+    )
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        dumped = lp.model_dump()
+    assert isinstance(dumped["top_logprobs"], list)
+    assert dumped["top_logprobs"][0]["Hello"] == -2.6e-06
+
+
+def test_logprobs_part_top_logprobs_optional():
+    """top_logprobs defaults to None when not supplied."""
+    lp = LogprobsPart(tokens=["hi"], token_logprobs=[-0.5])
+    assert lp.top_logprobs is None


### PR DESCRIPTION
*Have you read the [Contributing Guidelines](https://github.com/togethercomputer/together/blob/main/CONTRIBUTING.md)?*

Issue #443

## Describe your changes

`LogprobsPart` (in `src/together/types/common.py`) was missing a typed field for `top_logprobs`, even though the Together API returns it alongside `tokens` and `token_logprobs` when `logprobs=N` is requested.

Because `BaseModel` uses `extra="allow"`, the data was silently stored as an untyped extra attribute. Two problems result:
1. No static type information — IDEs and mypy treat `response.choices[0].logprobs.top_logprobs` as `Any`, losing all type safety.
2. `PydanticSerializationUnexpectedValue` warnings on `model_dump()` — when serializing, Pydantic sees a `list` value for a field that has no declared schema and emits a warning.

The fix adds:
```python
top_logprobs: List[Dict[str, float]] | None = None
```
to `LogprobsPart`, matching the actual API shape: one `dict` per token mapping each candidate token string to its log-probability.

Three unit tests are added to `tests/unit/test_logprobs_type.py`:
- Round-trip correctness: verify `top_logprobs` is parsed as `list[dict]`
- Warning-free `model_dump()` with warnings-as-errors enabled
- Default `None` when field is absent

## Summary

Added `top_logprobs: List[Dict[str, float]] | None = None` to `LogprobsPart` so that the field is fully typed, IDE-visible, and serializes without Pydantic warnings. Three regression tests cover the happy path, warning-free serialization, and the optional-field default.

## Issue

Fixes #443

## Local verification

```
$ PYTHONPATH=/tmp/together-python/src python -m pytest tests/unit/test_logprobs_type.py -v

============================= test session starts ==============================
platform linux -- Python 3.11.15, pytest-9.0.3, pluggy-1.6.0
rootdir: /tmp/together-python
configfile: pyproject.toml
collected 3 items

tests/unit/test_logprobs_type.py::test_logprobs_part_top_logprobs_is_list PASSED [ 33%]
tests/unit/test_logprobs_type.py::test_logprobs_part_model_dump_no_warning PASSED [ 66%]
tests/unit/test_logprobs_type.py::test_logprobs_part_top_logprobs_optional PASSED [100%]

$ PYTHONPATH=/tmp/together-python/src python -m pytest tests/unit/ -q

============ 6 failed, 177 passed, 14 warnings, 26 errors in 0.70s =============
(6 failures and 26 errors are pre-existing on upstream/main, confirmed by running
the same suite on the unpatched branch)

$ pre-commit run --files src/together/types/common.py tests/unit/test_logprobs_type.py

fix end of files.........................................................Passed
trim trailing whitespace.................................................Passed
check docstring is first.................................................Passed
check for merge conflicts................................................Passed
black....................................................................Passed
mypy.....................................................................Passed
=== LOCAL_TEST_PASSED ===
```

## Risk

Purely additive type annotation — no runtime behaviour change. The field defaults to `None`, so all existing callers that don't use `top_logprobs` are unaffected. Users who do access `response.choices[0].logprobs.top_logprobs` already receive the correct list value (stored via `extra="allow"`); this PR simply makes the field explicit and statically typed.
