### PR TITLE
Fix chat completion request and logprob contracts

### DIFF
--- a/src/together/resources/chat/completions.py
+++ b/src/together/resources/chat/completions.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any, AsyncGenerator, Dict, Iterator, List
+from typing import Any, AsyncGenerator, Dict, Iterator, List, Literal
 
 from together.abstract import api_requestor
 from together.together_response import TogetherResponse
@@ -32,6 +32,7 @@ class ChatCompletions:
         frequency_penalty: float | None = None,
         min_p: float | None = None,
         logit_bias: Dict[str, float] | None = None,
+        context_length_exceeded_behavior: Literal["truncate", "error"] | None = None,
         seed: int | None = None,
         stream: bool = False,
         logprobs: int | None = None,
@@ -80,6 +81,9 @@ class ChatCompletions:
             logit_bias (Dict[str, float], optional): A dictionary of tokens and their bias values that modify the
                 likelihood of specific tokens being sampled. Bias values must be in the range [-100, 100].
                 Defaults to None.
+            context_length_exceeded_behavior ("truncate" | "error", optional): Behavior when max_tokens exceeds the
+                model context length. "error" returns a 400, while "truncate" overrides max_tokens with the model's
+                maximum context length.
             seed (int, optional): A seed value to use for reproducibility.
             stream (bool, optional): Flag indicating whether to stream the generated completions.
                 Defaults to False.
@@ -126,6 +130,7 @@ class ChatCompletions:
             frequency_penalty=frequency_penalty,
             min_p=min_p,
             logit_bias=logit_bias,
+            context_length_exceeded_behavior=context_length_exceeded_behavior,
             seed=seed,
             stream=stream,
             logprobs=logprobs,
@@ -174,6 +179,7 @@ class AsyncChatCompletions:
         frequency_penalty: float | None = None,
         min_p: float | None = None,
         logit_bias: Dict[str, float] | None = None,
+        context_length_exceeded_behavior: Literal["truncate", "error"] | None = None,
         seed: int | None = None,
         stream: bool = False,
         logprobs: int | None = None,
@@ -222,6 +228,9 @@ class AsyncChatCompletions:
             logit_bias (Dict[str, float], optional): A dictionary of tokens and their bias values that modify the
                 likelihood of specific tokens being sampled. Bias values must be in the range [-100, 100].
                 Defaults to None.
+            context_length_exceeded_behavior ("truncate" | "error", optional): Behavior when max_tokens exceeds the
+                model context length. "error" returns a 400, while "truncate" overrides max_tokens with the model's
+                maximum context length.
             seed (int, optional): A seed value to use for reproducibility.
             stream (bool, optional): Flag indicating whether to stream the generated completions.
                 Defaults to False.
@@ -268,6 +277,7 @@ class AsyncChatCompletions:
             frequency_penalty=frequency_penalty,
             min_p=min_p,
             logit_bias=logit_bias,
+            context_length_exceeded_behavior=context_length_exceeded_behavior,
             seed=seed,
             stream=stream,
             logprobs=logprobs,

--- a/src/together/types/chat_completions.py
+++ b/src/together/types/chat_completions.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import warnings
 from enum import Enum
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Literal
 
 from pydantic import model_validator
 from typing_extensions import Self
@@ -132,6 +132,8 @@ class ChatCompletionRequest(BaseModel):
     frequency_penalty: float | None = None
     min_p: float | None = None
     logit_bias: Dict[str, float] | None = None
+    # behavior when max_tokens exceeds the model context length
+    context_length_exceeded_behavior: Literal["truncate", "error"] | None = None
     seed: int | None = None
     # stream SSE token chunks
     stream: bool = False

--- a/src/together/types/common.py
+++ b/src/together/types/common.py
@@ -42,6 +42,8 @@ class LogprobsPart(BaseModel):
     tokens: List[str | None] | None = None
     # token logprob list
     token_logprobs: List[float | None] | None = None
+    # top-k logprobs per token
+    top_logprobs: List[Dict[str, float]] | None = None
 
 
 class PromptPart(BaseModel):

--- a/tests/unit/test_chat_completion_contract.py
+++ b/tests/unit/test_chat_completion_contract.py
@@ -1,0 +1,59 @@
+import inspect
+
+from together.resources.chat.completions import AsyncChatCompletions, ChatCompletions
+from together.types.chat_completions import (
+    ChatCompletionRequest,
+    ChatCompletionResponse,
+)
+from together.types.common import LogprobsPart
+
+
+def test_chat_completion_create_exposes_context_length_behavior() -> None:
+    sync_signature = inspect.signature(ChatCompletions.create)
+    async_signature = inspect.signature(AsyncChatCompletions.create)
+
+    assert "context_length_exceeded_behavior" in sync_signature.parameters
+    assert "context_length_exceeded_behavior" in async_signature.parameters
+
+
+def test_chat_completion_request_serializes_context_length_behavior() -> None:
+    request = ChatCompletionRequest(
+        model="meta-llama/Llama-3.3-70B-Instruct-Turbo",
+        messages=[{"role": "user", "content": "Hello"}],
+        context_length_exceeded_behavior="truncate",
+    )
+
+    assert (
+        request.model_dump(exclude_none=True)["context_length_exceeded_behavior"]
+        == "truncate"
+    )
+
+
+def test_logprobs_part_models_top_logprobs_as_list_per_token() -> None:
+    assert "top_logprobs" in LogprobsPart.model_fields
+
+    response = ChatCompletionResponse(
+        choices=[
+            {
+                "logprobs": {
+                    "tokens": ["Hello", "."],
+                    "token_logprobs": [-0.1, -0.2],
+                    "top_logprobs": [
+                        {"Hello": -0.1, "Hi": -1.4},
+                        {".": -0.2, "!": -1.7},
+                    ],
+                }
+            }
+        ]
+    )
+
+    assert response.choices is not None
+    assert response.choices[0].logprobs is not None
+    assert response.choices[0].logprobs.top_logprobs == [
+        {"Hello": -0.1, "Hi": -1.4},
+        {".": -0.2, "!": -1.7},
+    ]
+    assert response.model_dump()["choices"][0]["logprobs"]["top_logprobs"] == [
+        {"Hello": -0.1, "Hi": -1.4},
+        {".": -0.2, "!": -1.7},
+    ]


### PR DESCRIPTION
## Summary
- expose `context_length_exceeded_behavior` on sync and async chat completion `create` calls
- serialize the option through `ChatCompletionRequest` using the documented `"truncate" | "error"` values
- model `LogprobsPart.top_logprobs` as a per-token `list[dict[str, float]]` so response dumps match the API shape
- add focused unit coverage for the public method signatures, request serialization, and response model dump behavior

Fixes #439.
Fixes #443.

## Why
The API reference documents `context_length_exceeded_behavior`, but the Python SDK did not surface it as an explicit chat completion parameter. Separately, issue #443 reports `top_logprobs` coming back as one dictionary per generated token, while the SDK contract did not model that field explicitly. Both gaps make typed SDK usage less reliable around long-context inference and logprob inspection.

## Validation
- `PYTHONPATH=src python3 -m pytest tests/unit/test_chat_completion_contract.py`
- `PYTHONPATH=src python3 -m black --check src/together/types/common.py src/together/types/chat_completions.py src/together/resources/chat/completions.py tests/unit/test_chat_completion_contract.py`
- `PYTHONPATH=src python3 -m compileall -q src/together tests/unit/test_chat_completion_contract.py`
- `git diff --check`