### PR TITLE
fix: normalize null and missing fields in streaming chat deltas

### DIFF
--- a/src/together/types/chat_completions.py
+++ b/src/together/types/chat_completions.py
@@ -185,12 +185,53 @@ class ChatCompletionResponse(BaseModel):
     usage: UsageData | None = None
 
 
+class ChatCompletionDeltaToolCalls(ToolCalls):
+    """One tool call fragment inside a streaming delta.
+
+    Streaming splits a single tool call across several chunks, so every
+    fragment carries an ``index`` naming the call it belongs to. The
+    non-streaming :class:`ToolCalls` has no such field, so the index is
+    declared on a streaming-only subclass. Putting it on the shared class
+    instead would add an ``index`` key to non-streaming
+    :class:`ChatCompletionMessage` dumps, which is why the subclass exists.
+    """
+
+    index: int | None = None
+
+
+class ChatCompletionDeltaContent(DeltaContent):
+    """Streaming delta for chat completion chunks.
+
+    The API returns an explicit ``null`` for ``choices[n].delta.tool_calls`` on
+    text-only chunks, and for ``function.name`` / ``function.arguments`` inside
+    tool-call fragments, where the OpenAI streaming format either omits the
+    field or sends an empty string, never ``null``
+    (https://github.com/togethercomputer/together-python/issues/160).
+
+    Declaring these as typed optional fields makes ``null`` and *missing* parse
+    identically (to ``None``) and validates the items into
+    :class:`ChatCompletionDeltaToolCalls`, matching the non-streaming
+    :class:`ChatCompletionMessage`, so ``model_dump(exclude_none=True)``
+    produces OpenAI-shaped deltas with the nulls omitted.
+
+    ``role`` is declared for the same reason. It is sent on the first chunk of
+    a response and left out of later ones, so while it was undeclared a present
+    role and an absent one behaved differently for callers. It is typed as
+    ``str`` rather than :class:`MessageRole` on purpose: chunks are parsed one
+    at a time inside the streaming generator, so an unrecognised role value
+    would otherwise raise part way through and end the stream.
+    """
+
+    role: str | None = None
+    tool_calls: List[ChatCompletionDeltaToolCalls] | None = None
+
+
 class ChatCompletionChoicesChunk(BaseModel):
     index: int | None = None
     logprobs: float | None = None
     seed: int | None = None
     finish_reason: FinishReason | None = None
-    delta: DeltaContent | None = None
+    delta: ChatCompletionDeltaContent | None = None
 
 
 class ChatCompletionChunk(BaseModel):

--- a/tests/unit/test_chat_completion_stream_types.py
+++ b/tests/unit/test_chat_completion_stream_types.py
@@ -1,0 +1,220 @@
+"""Regression tests for https://github.com/togethercomputer/together-python/issues/160
+
+The Together API returns an explicit ``null`` where the OpenAI streaming format
+either leaves the field out or sends an empty string, in three known places:
+
+1. ``choices[n].delta.tool_calls`` (text-only chunks, left out by OpenAI)
+2. ``choices[n].delta.tool_calls[n].function.arguments`` (first tool-call chunk,
+   where only the name is given; OpenAI sends an empty string here so that
+   consumers can concatenate every fragment without a special case)
+3. ``choices[n].delta.tool_calls[n].function.name`` (continuation chunks that
+   stream the JSON arguments incrementally, left out by OpenAI)
+
+``choices[n].delta.role`` has the same shape of problem from the other
+direction: it is sent on the first chunk and left out of the rest, so while it
+was undeclared a present role and an absent one behaved differently.
+
+These tests pin down that the parsed models normalize ``null`` to be
+indistinguishable from a missing field, so OpenAI-compatible consumers do not
+need Together-specific special cases.
+"""
+
+from together.types import ChatCompletionChunk, ChatCompletionResponse
+from together.types.chat_completions import FunctionCall, ToolCalls
+
+
+def _chunk(delta: dict) -> ChatCompletionChunk:
+    """Build a chunk the way the SDK does: ChatCompletionChunk(**line.data)."""
+    return ChatCompletionChunk(
+        **{
+            "id": "884581f24f0cfdd0-SJC",
+            "object": "chat.completion.chunk",
+            "created": 1725561260,
+            "model": "meta-llama/Meta-Llama-3.1-8B-Instruct-Turbo",
+            "choices": [{"index": 0, "delta": delta, "finish_reason": None}],
+        }
+    )
+
+
+# Wire payloads as observed in issue #160
+TEXT_ONLY_DELTA_WITH_NULL = {
+    "role": "assistant",
+    "content": "Hello",
+    "tool_calls": None,
+}
+TEXT_ONLY_DELTA_OMITTED = {"role": "assistant", "content": "Hello"}
+FIRST_TOOL_CALL_DELTA = {
+    "role": "assistant",
+    "content": None,
+    "tool_calls": [
+        {
+            "index": 0,
+            "id": "call_f7g2h8i9j0",
+            "type": "function",
+            "function": {"name": "get_current_weather", "arguments": None},
+        }
+    ],
+}
+CONTINUATION_TOOL_CALL_DELTA = {
+    "tool_calls": [
+        {
+            "index": 0,
+            "function": {"name": None, "arguments": '{"location": "San Fra'},
+        }
+    ]
+}
+
+
+def _has_no_none_values(obj: object) -> bool:
+    if obj is None:
+        return False
+    if isinstance(obj, dict):
+        return all(_has_no_none_values(v) for v in obj.values())
+    if isinstance(obj, list):
+        return all(_has_no_none_values(v) for v in obj)
+    return True
+
+
+def test_null_tool_calls_parses_like_omitted_tool_calls() -> None:
+    """`tool_calls: null` (text-only chunks) must behave exactly like a
+    missing `tool_calls` field: attribute exists and is None in both cases."""
+    with_null = _chunk(TEXT_ONLY_DELTA_WITH_NULL).choices[0].delta
+    omitted = _chunk(TEXT_ONLY_DELTA_OMITTED).choices[0].delta
+
+    assert with_null is not None and omitted is not None
+    assert with_null.tool_calls is None
+    assert omitted.tool_calls is None  # was AttributeError before the fix
+    assert with_null.content == omitted.content == "Hello"
+
+
+def test_tool_call_delta_items_are_typed_models() -> None:
+    """Streaming tool-call fragments parse into the same ToolCalls/FunctionCall
+    models used by the non-streaming ChatCompletionMessage."""
+    delta = _chunk(FIRST_TOOL_CALL_DELTA).choices[0].delta
+    assert delta is not None and delta.tool_calls is not None
+
+    (tool_call,) = delta.tool_calls
+    assert isinstance(tool_call, ToolCalls)
+    assert isinstance(tool_call.function, FunctionCall)
+    assert tool_call.id == "call_f7g2h8i9j0"
+    assert tool_call.type == "function"
+    assert tool_call.function.name == "get_current_weather"
+    # null arguments on the first chunk normalizes to None (absent)
+    assert tool_call.function.arguments is None
+
+
+def test_null_function_name_on_continuation_chunks() -> None:
+    """`function.name: null` on argument-continuation chunks normalizes to
+    None while the incremental arguments fragment is preserved verbatim."""
+    delta = _chunk(CONTINUATION_TOOL_CALL_DELTA).choices[0].delta
+    assert delta is not None and delta.tool_calls is not None
+
+    (tool_call,) = delta.tool_calls
+    assert tool_call.function is not None
+    assert tool_call.function.name is None
+    assert tool_call.function.arguments == '{"location": "San Fra'
+
+
+def test_exclude_none_dump_produces_openai_shaped_deltas() -> None:
+    """model_dump(exclude_none=True) must omit every API-provided null,
+    including the ones nested inside tool_calls[n].function."""
+    for wire_delta in (
+        TEXT_ONLY_DELTA_WITH_NULL,
+        TEXT_ONLY_DELTA_OMITTED,
+        FIRST_TOOL_CALL_DELTA,
+        CONTINUATION_TOOL_CALL_DELTA,
+    ):
+        delta = _chunk(wire_delta).choices[0].delta
+        assert delta is not None
+        dumped = delta.model_dump(exclude_none=True)
+        assert _has_no_none_values(dumped), f"None survived in {dumped!r}"
+
+    text_only = _chunk(TEXT_ONLY_DELTA_WITH_NULL).choices[0].delta
+    assert text_only is not None
+    assert "tool_calls" not in text_only.model_dump(exclude_none=True)
+
+
+def test_role_parses_the_same_whether_sent_or_left_out() -> None:
+    """`delta.role` is sent on the first chunk and left out of later ones, so
+    both must give the same attribute rather than one raising AttributeError."""
+    first = _chunk(TEXT_ONLY_DELTA_WITH_NULL).choices[0].delta
+    later = _chunk(CONTINUATION_TOOL_CALL_DELTA).choices[0].delta
+
+    assert first is not None and later is not None
+    assert first.role == "assistant"
+    assert later.role is None  # was AttributeError before the fix
+    # An unrecognised role must not end the stream, which is why the field is
+    # typed as str rather than the MessageRole enum.
+    assert _chunk({"role": "some_future_role"}).choices[0].delta.role == (
+        "some_future_role"
+    )
+
+
+def test_tool_call_index_is_typed_on_the_streaming_model_only() -> None:
+    """Streaming splits one tool call across chunks, so `index` says which call
+    a fragment belongs to.
+
+    It is declared on a streaming-only subclass. Declaring it on the shared
+    ToolCalls instead would add an `index` key to non-streaming message dumps,
+    so this pins the separation in both directions.
+    """
+    delta = _chunk(FIRST_TOOL_CALL_DELTA).choices[0].delta
+    assert delta is not None and delta.tool_calls is not None
+
+    (tool_call,) = delta.tool_calls
+    assert isinstance(tool_call, ToolCalls)
+    assert tool_call.index == 0
+    assert "index" in type(tool_call).model_fields
+    assert "index" not in ToolCalls.model_fields
+    assert delta.model_dump(exclude_none=True)["tool_calls"][0]["index"] == 0
+
+
+def test_undeclared_wire_fields_are_still_preserved() -> None:
+    """Fields the SDK does not declare must keep flowing through, as they did
+    before the fix (extra="allow"), so new API fields are never dropped."""
+    delta = (
+        _chunk({"role": "assistant", "content": "Hi", "future_field": 7})
+        .choices[0]
+        .delta
+    )
+    assert delta is not None
+    assert delta.future_field == 7  # type: ignore[attr-defined]
+    assert delta.model_dump(exclude_none=True)["future_field"] == 7
+
+
+def test_non_streaming_tool_calls_unchanged() -> None:
+    """Non-streaming responses keep parsing tool_calls into typed models."""
+    response = ChatCompletionResponse(
+        **{
+            "id": "884581f24f0cfdd0-SJC",
+            "object": "chat.completion",
+            "created": 1725561260,
+            "model": "meta-llama/Meta-Llama-3.1-8B-Instruct-Turbo",
+            "choices": [
+                {
+                    "index": 0,
+                    "finish_reason": "tool_calls",
+                    "message": {
+                        "role": "assistant",
+                        "content": None,
+                        "tool_calls": [
+                            {
+                                "id": "call_f7g2h8i9j0",
+                                "type": "function",
+                                "function": {
+                                    "name": "get_current_weather",
+                                    "arguments": '{"location": "San Francisco, CA"}',
+                                },
+                            }
+                        ],
+                    },
+                }
+            ],
+        }
+    )
+    assert response.choices is not None
+    message = response.choices[0].message
+    assert message is not None and message.tool_calls is not None
+    assert isinstance(message.tool_calls[0], ToolCalls)
+    assert message.tool_calls[0].function is not None
+    assert message.tool_calls[0].function.name == "get_current_weather"


### PR DESCRIPTION
*Have you read the [Contributing Guidelines](https://github.com/togethercomputer/together-python/blob/main/CONTRIBUTING.md)?* Yes.

Issue #160

## Describe your changes

**What and why.** Issue #160 reports that the API returns an explicit `null` where the OpenAI streaming format leaves the field out, in three places:

1. `choices[n].delta.tool_calls = null` on text only chunks.
2. `choices[n].delta.tool_calls[n].function.arguments = null` on the first tool call chunk, where the name is given.
3. `choices[n].delta.tool_calls[n].function.name = null` on argument continuation chunks.

The root cause is on the API side. This PR does not change the wire, it stops the SDK from passing the problem on. The streaming delta model (`DeltaContent`) declares only `content`, so everything else rides on `extra="allow"`. On current `main` that produces four separate problems, listed by how much they actually bite:

1. **Tool call fragments come back as raw dicts**, not the `ToolCalls` and `FunctionCall` models the non streaming `ChatCompletionMessage` uses. So the same tool call has two different shapes depending on whether you streamed it.
2. **`model_dump(exclude_none=True)` does not strip the nulls nested inside those raw dicts**, so `{"function": {"arguments": None}}` and `{"function": {"name": None}}` reach OpenAI compatible consumers even when the caller asked for nulls to be dropped.
3. **`delta.role` raises `AttributeError` on continuation chunks.** The API sends `role` on the first chunk of a response and leaves it out afterwards, so the same attribute works or raises depending on which chunk you are holding.
4. **`delta.tool_calls` raises `AttributeError` when the field is absent.** Worth being precise here: an explicit `"tool_calls": null` already parses to `None` on `main`, so this one does not fire on Together's own responses today. It fires on the OpenAI shape, where the key is left out. It is the same defect as 3, one field over, and it is the one the issue title points at, so it is fixed rather than left as a trap.

**The fix.** Two small classes in `src/together/types/chat_completions.py`, and `ChatCompletionChoicesChunk.delta` now uses the first:

```python
class ChatCompletionDeltaToolCalls(ToolCalls):
    index: int | None = None

class ChatCompletionDeltaContent(DeltaContent):
    role: str | None = None
    tool_calls: List[ChatCompletionDeltaToolCalls] | None = None
```

That gives:

1. `null` and missing both parse to `None` for `role` and `tool_calls`, so the two are no longer distinguishable. `FunctionCall.name` and `.arguments` were already `str | None`, so the nested nulls normalize the same way once the items are validated.
2. Fragments validate into typed models, so streaming and non streaming agree, and it matches how `openai-python` types its deltas (`ChoiceDeltaToolCallFunction.name` and `.arguments` are `Optional[str]`).
3. `model_dump(exclude_none=True)` now recursively drops the API provided nulls.

Deliberate decisions:

1. **`index` goes on a streaming only subclass.** Streaming splits one tool call across chunks, so callers need `index` to reassemble them, but the non streaming `ToolCalls` has no such field. Subclassing keeps `index` out of `ChatCompletionMessage.tool_calls` dumps. A test asserts it in both directions.
2. **`role` is typed `str`, not `MessageRole`.** Chunks are parsed one at a time inside the streaming generator, so an unrecognised role value from a future model would otherwise raise part way through and end the stream.
3. **No coercion of `None` into an empty string for `arguments`.** openai-python also leaves absent fields as `None`; coercing would diverge from it and silently change `is None` checks.
4. **Text completion deltas untouched.** `DeltaContent` is shared with `CompletionChunk`, so the new fields are added on a chat specific subclass rather than the shared class.
5. **No wire or request changes.** Request serialization is unaffected, and the request bytes are identical before and after.

Sync and async clients share these models (`ChatCompletionChunk(**line.data)` at both call sites in `resources/chat/completions.py`), so both are covered.

## Known limitations

1. **The root cause is on the API side; this is client side hardening.** Raw HTTP consumers and other SDKs still see the nulls on the wire. I did not have an API key to re-probe the live wire, so the payload shapes here come from the issue itself rather than a fresh capture. The SDK level behaviour reproduces deterministically from those payloads either way. Marked "Related to" rather than "Fixes" for that reason: the server side half is still open.
2. **This makes the SDK stricter about the shape of streaming tool calls, and that can end a stream.** Before this change, a fragment whose fields had the wrong type was passed through untouched as a dict. Now it raises a pydantic `ValidationError`, and because chunks are parsed one at a time inside the generator, that error ends the stream and the caller loses every remaining chunk, including plain text that had nothing to do with tool calls. Payloads that used to pass and now raise include `function.arguments` sent as a parsed object instead of a JSON string, `tool_calls` sent as a dict instead of a list, and `id` sent as an integer. This is the same strictness the non streaming `ChatCompletionMessage.tool_calls` has had all along, so it makes the two paths consistent rather than inventing a new rule, but it is a real behaviour change and worth a maintainer's judgement.
3. **Source level breaks for anyone who worked around the bug.** Fragments were dicts, so `delta.tool_calls[0]["function"]` worked; it now raises `TypeError: 'ToolCalls' object is not subscriptable` and needs attribute access. That is exactly the population that hit this issue. Also, a plain `model_dump()` without `exclude_none=True` of a text only delta now includes `tool_calls: None` and `role`, which is standard Pydantic optional field behaviour and matches `ChatCompletionMessage` and openai-python.
4. **The new types are not exported from `together.types.__all__`.** `ChatCompletionDeltaContent` is now the runtime type of every chat stream delta, so there is a case for exporting it, but that touches another file and I kept the diff to the fix. Happy to add it.
5. **V1 is in maintenance mode** (V2 lives in `together-py`), so this is scoped as a small maintenance bug fix. The underlying API cleanup this issue asks for is still worth doing server side.

## Testing

New file `tests/unit/test_chat_completion_stream_types.py`, 8 tests using chunk fixtures shaped exactly like the issue's three instances, plus a missing field control, an undeclared field passthrough check, an `exclude_none` recursive dump assertion, and a non streaming regression control.

Fail then pass, with the new tests run against unfixed `main`:

```
6 failed, 2 passed
AttributeError: 'DeltaContent' object has no attribute 'tool_calls'
AttributeError: 'DeltaContent' object has no attribute 'role'
AttributeError: 'dict' object has no attribute 'function'
AssertionError: None survived in {'role': 'assistant', 'tool_calls': [{'index': 0, ... 'arguments': None}}]}
```

The 2 that pass on `main` are the deliberate controls: the non streaming path is untouched, and undeclared fields still flow through.

On this branch the full offline suite is `214 passed`, against `206 passed` on `main`, and the difference is exactly the new file. No existing test changed. `ruff` and `black` are clean on both changed files, and `mypy --strict` reports the same 5 pre existing errors in unrelated files before and after.

Everything runs offline. The tests build models from literal dicts, so no client is constructed, no key is read, and no host is named. I confirmed that by re-running them with `socket.socket.connect`, `socket.create_connection`, `socket.getaddrinfo` and `ssl.SSLContext.wrap_socket` all replaced with a raiser, after first checking the block itself fires.
