### PR TITLE
Document what logprobs returns and bound it to the documented range

### DIFF
--- a/src/together/resources/chat/completions.py
+++ b/src/together/resources/chat/completions.py
@@ -83,7 +83,9 @@ class ChatCompletions:
             seed (int, optional): A seed value to use for reproducibility.
             stream (bool, optional): Flag indicating whether to stream the generated completions.
                 Defaults to False.
-            logprobs (int, optional): Number of top-k logprobs to return
+            logprobs (int, optional): Number of top tokens to return log probabilities for
+                at each generation step, instead of only the sampled token.
+                Must be in the range [0, 20].
                 Defaults to None.
             echo (bool, optional): Echo prompt in output. Can be used with logprobs to return prompt logprobs.
                 Defaults to None.
@@ -225,7 +227,9 @@ class AsyncChatCompletions:
             seed (int, optional): A seed value to use for reproducibility.
             stream (bool, optional): Flag indicating whether to stream the generated completions.
                 Defaults to False.
-            logprobs (int, optional): Number of top-k logprobs to return
+            logprobs (int, optional): Number of top tokens to return log probabilities for
+                at each generation step, instead of only the sampled token.
+                Must be in the range [0, 20].
                 Defaults to None.
             echo (bool, optional): Echo prompt in output. Can be used with logprobs to return prompt logprobs.
                 Defaults to None.

--- a/src/together/resources/completions.py
+++ b/src/together/resources/completions.py
@@ -79,7 +79,9 @@ class Completions:
             seed (int, optional): Seed value for reproducibility.
             stream (bool, optional): Flag indicating whether to stream the generated completions.
                 Defaults to False.
-            logprobs (int, optional): Number of top-k logprobs to return
+            logprobs (int, optional): Number of top tokens to return log probabilities for
+                at each generation step, instead of only the sampled token.
+                Must be in the range [0, 20].
                 Defaults to None.
             echo (bool, optional): Echo prompt in output. Can be used with logprobs to return prompt logprobs.
                 Defaults to None.
@@ -203,7 +205,9 @@ class AsyncCompletions:
             seed (int, optional): Seed value for reproducibility.
             stream (bool, optional): Flag indicating whether to stream the generated completions.
                 Defaults to False.
-            logprobs (int, optional): Number of top-k logprobs to return
+            logprobs (int, optional): Number of top tokens to return log probabilities for
+                at each generation step, instead of only the sampled token.
+                Must be in the range [0, 20].
                 Defaults to None.
             echo (bool, optional): Echo prompt in output. Can be used with logprobs to return prompt logprobs.
                 Defaults to None.

--- a/src/together/types/chat_completions.py
+++ b/src/together/types/chat_completions.py
@@ -4,7 +4,7 @@ import warnings
 from enum import Enum
 from typing import Any, Dict, List
 
-from pydantic import model_validator
+from pydantic import Field, model_validator
 from typing_extensions import Self
 
 from together.types.abstract import BaseModel
@@ -135,8 +135,9 @@ class ChatCompletionRequest(BaseModel):
     seed: int | None = None
     # stream SSE token chunks
     stream: bool = False
-    # return logprobs
-    logprobs: int | None = None
+    # return logprobs. The API accepts 0 to 20, the number of top tokens to
+    # return log probabilities for at each generation step.
+    logprobs: int | None = Field(default=None, ge=0, le=20)
     # echo prompt.
     # can be used with logprobs to return prompt logprobs
     echo: bool | None = None

--- a/src/together/types/completions.py
+++ b/src/together/types/completions.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import warnings
 from typing import Dict, List
 
-from pydantic import model_validator
+from pydantic import Field, model_validator
 from typing_extensions import Self
 
 from together.types.abstract import BaseModel
@@ -38,8 +38,9 @@ class CompletionRequest(BaseModel):
     seed: int | None = None
     # stream SSE token chunks
     stream: bool = False
-    # return logprobs
-    logprobs: int | None = None
+    # return logprobs. The API accepts 0 to 20, the number of top tokens to
+    # return log probabilities for at each generation step.
+    logprobs: int | None = Field(default=None, ge=0, le=20)
     # echo prompt.
     # can be used with logprobs to return prompt logprobs
     echo: bool | None = None

--- a/tests/unit/test_logprobs.py
+++ b/tests/unit/test_logprobs.py
@@ -1,0 +1,162 @@
+"""Tests for the logprobs request parameter and top_logprobs response data.
+
+The Together API accepts ``logprobs`` as an integer between 0 and 20: the
+number of top tokens to return log probabilities for at each generation
+step, instead of only the sampled token (see issue #251). When top-k
+logprobs are requested, each choice's ``logprobs`` part carries a
+``top_logprobs`` list with one ``{token: logprob}`` dict per generated
+token.
+"""
+
+import json
+import warnings
+
+import pytest
+from pydantic import ValidationError
+
+from together.types import ChatCompletionRequest, CompletionRequest
+from together.types.chat_completions import ChatCompletionResponse
+
+
+MESSAGES = [{"role": "user", "content": "Say hello."}]
+MODEL = "meta-llama/Llama-3.3-70B-Instruct-Turbo"
+
+# Response shape documented for the chat completions API with ``logprobs=3``:
+# ``top_logprobs`` is a list with one dict of the top-k alternatives per
+# generated token.
+TOP_LOGPROBS = [
+    {"Hello": -2.6e-06, "hello": -13.5, " Hello": -13.875},
+    {".": -4.8e-05, "!": -10.0625, ".\n": -11.4375},
+]
+RESPONSE_PAYLOAD = {
+    "id": "889ee12e7b0b3c67",
+    "object": "chat.completion",
+    "created": 1709240335,
+    "model": MODEL,
+    "choices": [
+        {
+            "index": 0,
+            "finish_reason": "eos",
+            "logprobs": {
+                "tokens": ["Hello", "."],
+                "token_logprobs": [-2.6e-06, -4.8e-05],
+                "top_logprobs": TOP_LOGPROBS,
+            },
+            "message": {"role": "assistant", "content": "Hello."},
+        }
+    ],
+    "usage": {"prompt_tokens": 4, "completion_tokens": 2, "total_tokens": 6},
+}
+
+# A value the API rejects, used to trigger the range error.
+OUT_OF_RANGE = 50
+# Stand in for private prompt text, so a leak is easy to spot.
+SECRET_PROMPT = "unique prompt text that must not escape into an exception"
+
+RANGE_ERROR_TYPES = {"greater_than_equal", "less_than_equal"}
+
+
+def _assert_scoped_range_error(error: ValidationError, sent: int) -> None:
+    """The error must name the logprobs field and carry only that value.
+
+    Scoping matters for privacy as well as for clarity. A model level
+    validator reports the whole request as the offending input, which places
+    the prompt or the message list inside the exception, and from there into
+    any log line or crash reporter that serializes ``errors()``.
+    """
+    details = error.errors()
+    assert len(details) == 1
+    assert details[0]["loc"] == ("logprobs",)
+    assert details[0]["type"] in RANGE_ERROR_TYPES
+    assert details[0]["input"] == sent
+
+
+@pytest.mark.parametrize("logprobs", [-1, 21, 100])
+def test_chat_request_rejects_out_of_range_logprobs(logprobs: int) -> None:
+    with pytest.raises(ValidationError) as excinfo:
+        ChatCompletionRequest(model=MODEL, messages=MESSAGES, logprobs=logprobs)
+
+    _assert_scoped_range_error(excinfo.value, logprobs)
+
+
+@pytest.mark.parametrize("logprobs", [-1, 21, 100])
+def test_completion_request_rejects_out_of_range_logprobs(logprobs: int) -> None:
+    with pytest.raises(ValidationError) as excinfo:
+        CompletionRequest(model=MODEL, prompt="Say hello.", logprobs=logprobs)
+
+    _assert_scoped_range_error(excinfo.value, logprobs)
+
+
+@pytest.mark.parametrize("logprobs", [0, 1, 20])
+def test_chat_request_accepts_in_range_logprobs(logprobs: int) -> None:
+    request = ChatCompletionRequest(model=MODEL, messages=MESSAGES, logprobs=logprobs)
+
+    # 0 is a valid value and must survive serialization of the payload.
+    assert request.model_dump(exclude_none=True)["logprobs"] == logprobs
+
+
+@pytest.mark.parametrize("logprobs", [0, 1, 20])
+def test_completion_request_accepts_in_range_logprobs(logprobs: int) -> None:
+    request = CompletionRequest(model=MODEL, prompt="Say hello.", logprobs=logprobs)
+
+    assert request.model_dump(exclude_none=True)["logprobs"] == logprobs
+
+
+def test_request_logprobs_defaults_to_omitted() -> None:
+    request = ChatCompletionRequest(model=MODEL, messages=MESSAGES)
+
+    assert "logprobs" not in request.model_dump(exclude_none=True)
+
+
+def test_chat_range_error_leaves_the_messages_out_of_the_exception() -> None:
+    """Rejecting a bad logprobs value must not expose the conversation.
+
+    Before this check existed the request reached the server and came back as
+    an API error that did not repeat the prompt. A client side check has to
+    keep that property, otherwise moving validation earlier would hand user
+    text to every logger that records the traceback.
+    """
+    with pytest.raises(ValidationError) as excinfo:
+        ChatCompletionRequest(
+            model=MODEL,
+            messages=[{"role": "user", "content": SECRET_PROMPT}],
+            logprobs=OUT_OF_RANGE,
+        )
+
+    assert SECRET_PROMPT not in str(excinfo.value)
+    assert SECRET_PROMPT not in json.dumps(excinfo.value.errors(), default=str)
+
+
+def test_completion_range_error_leaves_the_prompt_out_of_the_exception() -> None:
+    with pytest.raises(ValidationError) as excinfo:
+        CompletionRequest(model=MODEL, prompt=SECRET_PROMPT, logprobs=OUT_OF_RANGE)
+
+    assert SECRET_PROMPT not in str(excinfo.value)
+    assert SECRET_PROMPT not in json.dumps(excinfo.value.errors(), default=str)
+
+
+def test_top_logprobs_survive_parsing_and_model_dump() -> None:
+    """Top-k alternatives must round-trip through the response models.
+
+    ``LogprobsPart`` declares only ``tokens`` and ``token_logprobs`` today, so
+    ``top_logprobs`` survives on the SDK's base model setting
+    ``extra="allow"``: the value is carried untyped and dumped back unchanged.
+    This test pins the round-trip rather than the declaration, so it holds
+    either way, and it fails if the field is ever declared with the wrong
+    shape, for example as a ``Dict[str, float]`` rather than a list of
+    per-token dicts. Open PR #452 proposes declaring it as
+    ``List[Dict[str, float]]``, which this test already accepts. It does not
+    constrain what the server sends.
+    """
+    response = ChatCompletionResponse(**RESPONSE_PAYLOAD)
+
+    assert response.choices is not None
+    logprobs_part = response.choices[0].logprobs
+    assert logprobs_part is not None
+    assert logprobs_part.top_logprobs == TOP_LOGPROBS
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        dumped = response.model_dump()
+
+    assert dumped["choices"][0]["logprobs"]["top_logprobs"] == TOP_LOGPROBS


### PR DESCRIPTION
*Have you read the [Contributing Guidelines](https://github.com/togethercomputer/together-python/blob/main/CONTRIBUTING.md)?* Yes.

Issue #251

## Describe your changes

**What and why.** Issue #251 asks how to get log probabilities for more than just the sampled token. The answer is the `logprobs` parameter, which takes the number of top tokens to score at each step, but nothing in the SDK says so. All four `create()` docstrings read:

```
logprobs (int, optional): Number of top-k logprobs to return
```

which reads as "how many logprobs come back" rather than "how many alternatives per token", and gives no range. The documented range is 0 to 20 for both [chat completions](https://docs.together.ai/reference/chat-completions-1) and [text completions](https://docs.together.ai/reference/completions-1): "An integer between 0 and 20 of the top k tokens to return log probabilities for at each generation step." Out of range values were only rejected by the server, so the round trip was spent before finding out.

**The fix.** Two parts.

1. Say what the parameter does, in all four `create()` docstrings (sync and async, chat and text), including the range.
2. Bound the field to the documented range:

```python
logprobs: int | None = Field(default=None, ge=0, le=20)
```

on `ChatCompletionRequest` and `CompletionRequest`, so a bad value fails locally instead of after a request.

**Why on the field and not in the validator.** `verify_parameters` already exists on both models and was the obvious place, but a `mode="after"` model validator reports the whole request as the offending input. That puts the message list or the prompt inside the exception:

```python
e.errors()[0]["input"]
# {'model': '...', 'messages': [{'role': 'user', 'content': 'PATIENT NAME: ...'}], 'logprobs': 50}
```

`str(e)` truncates it, so it looks harmless, but anything that serializes `errors()`, such as a crash reporter or structured logging, captures the prompt verbatim. Before this change the request went to the server and came back as an API error that did not repeat the prompt, so moving validation earlier should not hand user text to every logger. A field constraint keeps the error scoped:

```python
e.errors()[0]["loc"]    # ('logprobs',)
e.errors()[0]["input"]  # 50
```

It also puts the range in the generated JSON schema, and it is less code than the validator branch. Two tests pin the prompt staying out of the exception, one per request model.

## Known limitations

1. **This is the first hard client side rejection of a pass through inference parameter in this SDK, and that is a judgement call.** The parameter directly below it in the same docstring, `logit_bias`, documents its range of [-100, 100] and does not enforce it, and the same is true of `temperature`, `top_p`, `min_p` and `n`. The existing `verify_parameters` validator only ever warns. I enforced here because the range is documented for both endpoints and an out of range value can never succeed, so failing early is strictly faster. If you would rather keep the SDK consistent and permissive, say so and I will switch it to `warnings.warn`, matching `repetition_penalty`.
2. **The range is hardcoded from today's API docs.** If the service ever raises the cap, a pinned SDK will reject requests the server would accept, and the caller has no override.
3. **The error is a pydantic `ValidationError`, not a `TogetherException`.** Code shaped like `except together.error.InvalidRequestError:` around `create()` used to catch an out of range `logprobs`, because the rejection came back from the server. It will not catch it now.
4. **The CLI reports it as a traceback, not a usage error.** `--logprobs` is a plain `click` `type=int` on both `chat.py` and `completions.py`, so an out of range value reaches the model and surfaces as a pydantic traceback rather than a clean click message. Adding `click.IntRange(0, 20)` there would fix it, but it is a separate change in two more files and I kept this diff small.
5. **Streaming plus logprobs is still not usable, and this PR does not fix it.** `ChatCompletionChoicesChunk.logprobs` and `CompletionChoicesChunk.logprobs` are typed `float | None`, while the non streaming models use the `LogprobsPart` object. The same `create()` methods whose docstrings this PR rewrites also accept `stream=True`, so anyone following the new documentation with streaming on will hit a parse failure if the server sends the object shape on chunks. I had no API key to confirm the streaming wire shape, so I have not widened the type on a guess. Worth a follow up either way.
6. **`logprobs=True` is silently accepted as 1.** `bool` subclasses `int`, and pydantic accepts it in lax mode, so a caller coming from the OpenAI SDK, where chat `logprobs` is a boolean and the count lives in a separate `top_logprobs` field, gets top 1 rather than an error. Pre existing, unchanged here, noted because the new docstring says "integer".
7. **The bound is checked at construction, not on assignment.** The models do not set `validate_assignment`, so setting `request.logprobs = 999` afterwards survives. Every `create()` builds the model in one shot, so this is not reachable through the public API today.
8. **V1 is in maintenance mode** (V2 lives in `together-py`). The docstring half is a plain documentation fix; the validation half is a behaviour change, so it is reasonable to want it in 2.0 instead. Happy to split them.

## Testing

New file `tests/unit/test_logprobs.py`, 16 tests: 6 rejection cases across both request models, 6 acceptance cases including 0 and 20 as boundaries, one that `logprobs` stays out of the serialized payload when unset, two that the rejection does not carry the prompt, and one response side round trip.

Fail then pass: run against unfixed `main`, the 6 rejection tests fail with `DID NOT RAISE ValidationError`. On this branch the full offline suite is `222 passed`, against `206 passed` on `main`, and the difference is exactly the new file. No existing test changed.

**Relation to open PR #452.** #452 ("Fix chat completion request and logprob contracts") touches two of the same files and proposes declaring `top_logprobs: List[Dict[str, float]]` on `LogprobsPart`. The two are compatible and independent: #452 is response side typing, this PR is request side validation plus docstrings. I checked rather than assumed. They merge cleanly with `git merge-tree`, and all 16 tests here still pass with #452's typed field applied locally. If #452 lands first, nothing here needs changing. Whichever order suits you is fine by me.

The response side test deserves a caveat rather than a claim. `top_logprobs` is not a declared field on `LogprobsPart`, which declares only `tokens` and `token_logprobs`. It survives because the base model sets `extra="allow"`, so the value is carried untyped and dumped back unchanged. That test pins the pass through and fails if the field is later declared with the wrong shape. It does not constrain what the server sends, and no source change in this PR affects that path. The test docstring says exactly that.

`ruff` reports one `I001` on `src/together/resources/completions.py`, identical on `main`, in an import block this PR does not touch, so it is left alone per the contribution guide. `black` is clean and `mypy --strict` reports the same 14 pre existing errors in unrelated files before and after.

Everything runs offline. All 16 tests pass with socket creation and DNS raising and no API key set.

Addresses #251.
